### PR TITLE
Add support for SX1280

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,3 +35,17 @@ board = heltec_wifi_lora_32
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
+
+;upload_port = 192.168.67.26
+;upload_port = 192.168.67.38
+;upload_port = 192.168.67.230
+;upload_port = 192.168.67.231
+;upload_port = 192.168.67.81
+;upload_port = 192.168.67.247
+;upload_port = 192.168.67.128
+;upload_port = 192.168.67.207
+;upload_port = 192.168.67.59
+;upload_port = 192.168.67.66
+;upload_port = /dev/cu.usbserial-1D11340
+;upload_port = /dev/cu.usbserial-0236E243 ;KG4DYD_2400_1
+upload_port = /dev/cu.usbserial-0236E0A4 ;KG4DYD_2400_2

--- a/tinyGS/src/ConfigManager/ConfigManager.cpp
+++ b/tinyGS/src/ConfigManager/ConfigManager.cpp
@@ -47,6 +47,8 @@ ConfigManager::ConfigManager()
                                                                                                                                         {0x3c, 21, 22, 16, 38, 22, 1, 18, 26, 33, 0, 14, 19, 27, 5, 0.0f, "T-BEAM V1.0 + OLED"},                                         // @fafu
                                                                                                                                         {0x3c, 21, 22, 16, 0, 2, 0, 5, 0, 34, 32, 14, 19, 27, 18, 1.6f, "433Mhz FOSSA 1W Ground Station"},                               // @jgromes
                                                                                                                                         {0x3c, 21, 22, 16, 0, 2, 0, 5, 0, 34, 32, 14, 19, 27, 18, 1.6f, "868-915Mhz FOSSA 1W Ground Station"},                           // @jgromes
+                                                                                                                                        {0x3c, 21, 22, 0, 0, 25, 1, 18, 26, 33, 32, 23, 19, 27, 5, 0.0f, "433/470/868/915 MHz TTGO T3 V2.1.6"},     // @rjason
+                                                                                                                                        {0x3c, 21, 22, 0, 0, 0, 2, 18, 26, 33, 0, 23, 19, 27, 5, 0.0f, "2400 MHz ESP32 / E28-2G4MxxS"},             // @rjason
                                                                                                                                     })
 {
   server.on(ROOT_URL, [this] { handleRoot(); });

--- a/tinyGS/src/ConfigManager/ConfigManager.h
+++ b/tinyGS/src/ConfigManager/ConfigManager.h
@@ -85,8 +85,10 @@ enum boardNum
   TBEAM_OLED_v1_0,
   ESP32_SX126X_TXC0_1W_LF,
   ESP32_SX126X_TXC0_1W_HF,
+  TTGO_T3_V2_1_6,
+  ESP32_E28_2G4MxxS,
 
-  NUM_BOARDS //this line always has to be the last one
+    NUM_BOARDS //this line always has to be the last one
 };
 
 typedef struct

--- a/tinyGS/src/ConfigManager/html.h
+++ b/tinyGS/src/ConfigManager/html.h
@@ -43,10 +43,12 @@ const char BOARD_NAMES[][BOARD_NAME_LENGTH] PROGMEM =
   "T-BEAM V1.0 + OLED" ,
   "433Mhz FOSSA 1W Ground Station",
   "868-915Mhz FOSSA 1W Ground Station",
+  "433/470/868/915 MHz TTGO T3 V2.1.6",
+  "2400 MHz ESP32 / E28-2G4MxxS",
 };
 
 constexpr auto BOARD_LENGTH = 3;
-const char BOARD_VALUES[][BOARD_LENGTH] PROGMEM = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16" };
+const char BOARD_VALUES[][BOARD_LENGTH] PROGMEM = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16" , "17" , "18" };
 
 const char IOTWEBCONF_DASHBOARD_STYLE_INNER[] PROGMEM = "table{margin:20px auto;}h3{text-align:center;}.card{height:12em;margin:10px;text-align:left;font-family:Arial;border:3px groove;border-radius:0.3rem;display:inline-block;padding:10px;min-width:260px;}td{padding:0 10px;}textarea{resize:vertical;width:100%;margin:0;height:318px;padding:5px;overflow:auto;}#c1{width:98%;padding:5px;}#t1{width:98%}.console{display:inline-block;text-align:center;margin:10px 0;width:98%;max-width:1080px;}.G{color:green;}.R{color:red}";
 const char IOTWEBCONF_DASHBOARD_BODY_INNER[] PROGMEM   = "<div style='text-align:center;min-width:260px;'>\n";

--- a/tinyGS/src/Radio/Radio.cpp
+++ b/tinyGS/src/Radio/Radio.cpp
@@ -74,14 +74,31 @@ void Radio::init()
 
   spi.begin(board.L_SCK, board.L_MISO, board.L_MOSI, board.L_NSS);
 
-  if (board.L_SX127X)
-  {
-    lora = new SX1278(new Module(board.L_NSS, board.L_DI00, board.L_DI01, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
-  }
-  else
-  {
-    lora = new SX1268(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
-  }
+//  if (board.L_SX127X)
+//  {
+//    lora = new SX1278(new Module(board.L_NSS, board.L_DI00, board.L_DI01, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
+//  }
+//  else
+//  {
+//    lora = new SX1268(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
+//  }
+    switch (board.L_SX127X) {
+        case 0: // SX126x
+            lora = new SX1268(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi,
+                                         SPISettings(2000000, MSBFIRST, SPI_MODE0)));
+            break;
+        case 1: // SX127x
+            lora = new SX1278(new Module(board.L_NSS, board.L_DI00, board.L_DI01, spi,
+                                         SPISettings(2000000, MSBFIRST, SPI_MODE0)));
+            break;
+        case 2: // SX128x
+            lora = new SX1280(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_DI00, spi,
+                                         SPISettings(2000000, MSBFIRST, SPI_MODE0)));
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
+
 
   begin();
 }
@@ -95,45 +112,108 @@ int16_t Radio::begin()
 
   if (m.modem_mode == "LoRa")
   {
-    if (board.L_SX127X)
-    {
-      state = ((SX1278 *)lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw, m.power, m.preambleLength, m.gain);
-      if (m.fldro == 2)
-        ((SX1278 *)lora)->autoLDRO();
-      else
-        ((SX1278 *)lora)->forceLDRO(m.fldro);
-
-      ((SX1278 *)lora)->setCRC(m.crc);
-    }
-    else
-    {
-      state = ((SX1268 *)lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw, m.power, m.preambleLength, board.L_TCXO_V);
-      if (m.fldro == 2)
-        ((SX1268 *)lora)->autoLDRO();
-      else
-        ((SX1268 *)lora)->forceLDRO(m.fldro);
-
-      ((SX1268 *)lora)->setCRC(m.crc);
-    }
+//    if (board.L_SX127X)
+//    {
+//      state = ((SX1278 *)lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw, m.power, m.preambleLength, m.gain);
+//      if (m.fldro == 2)
+//        ((SX1278 *)lora)->autoLDRO();
+//      else
+//        ((SX1278 *)lora)->forceLDRO(m.fldro);
+//
+//      ((SX1278 *)lora)->setCRC(m.crc);
+//    }
+//    else
+//    {
+//      state = ((SX1268 *)lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw, m.power, m.preambleLength, board.L_TCXO_V);
+//      if (m.fldro == 2)
+//        ((SX1268 *)lora)->autoLDRO();
+//      else
+//        ((SX1268 *)lora)->forceLDRO(m.fldro);
+//
+//      ((SX1268 *)lora)->setCRC(m.crc);
+//    }
+      switch (board.L_SX127X) {
+          case 0: // SX126x
+              state = ((SX1268 *) lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw,
+                                               m.power, m.preambleLength, board.L_TCXO_V);
+              if (m.fldro == 2)
+                  ((SX1268 *) lora)->autoLDRO();
+              else
+                  ((SX1268 *) lora)->forceLDRO(m.fldro);
+              ((SX1268 *) lora)->setCRC(m.crc);
+              break;
+          case 1: // SX127x
+              state = ((SX1278 *) lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw,
+                                               m.power, m.preambleLength, m.gain);
+              if (m.fldro == 2)
+                  ((SX1278 *) lora)->autoLDRO();
+              else
+                  ((SX1278 *) lora)->forceLDRO(m.fldro);
+              ((SX1278 *) lora)->setCRC(m.crc);
+              break;
+          case 2: // SX128x
+              state = ((SX1280 *) lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.power,
+                                               m.preambleLength);
+              //if (m.fldro == 2)
+              //    ((SX1280 *) lora)->autoLDRO();
+              //else
+              //    ((SX1280 *) lora)->forceLDRO(m.fldro);
+              ((SX1280 *) lora)->setCRC(m.crc);
+              break;
+          default: // Undefined
+              Log::console(PSTR("Board Type in Undefined ... "));
+      }
   }
   else
   {
-    if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    {
-      state = ((SX1278 *)lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev, m.bw, m.power, m.preambleLength, (m.OOK != 255));
-      ((SX1278 *)lora)->setDataShaping(m.OOK);
-      ((SX1278 *)lora)->startReceive();
-      ((SX1278 *)lora)->setDio0Action(setFlag);
-      ((SX1278 *)lora)->setSyncWord(m.fsw, m.swSize);
-    }
-    else
-    {
-      state = ((SX1268 *)lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev, m.bw, m.power, m.preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
-      ((SX1268 *)lora)->setDataShaping(m.OOK);
-      ((SX1268 *)lora)->startReceive();
-      ((SX1268 *)lora)->setDio1Action(setFlag);
-      state = ((SX1268 *)lora)->setSyncWord(m.fsw, m.swSize);
-    }
+//    if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    {
+//      state = ((SX1278 *)lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev, m.bw, m.power, m.preambleLength, (m.OOK != 255));
+//      ((SX1278 *)lora)->setDataShaping(m.OOK);
+//      ((SX1278 *)lora)->startReceive();
+//      ((SX1278 *)lora)->setDio0Action(setFlag);
+//      ((SX1278 *)lora)->setSyncWord(m.fsw, m.swSize);
+//    }
+//    else
+//    {
+//      state = ((SX1268 *)lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev, m.bw, m.power, m.preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
+//      ((SX1268 *)lora)->setDataShaping(m.OOK);
+//      ((SX1268 *)lora)->startReceive();
+//      ((SX1268 *)lora)->setDio1Action(setFlag);
+//      state = ((SX1268 *)lora)->setSyncWord(m.fsw, m.swSize);
+//    }
+      switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+          case 0: // SX126x
+              state = ((SX1268 *) lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev,
+                                                  m.bw,
+                                                  m.power, m.preambleLength,
+                                                  ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
+              ((SX1268 *) lora)->setDataShaping(m.OOK);
+              ((SX1268 *) lora)->startReceive();
+              ((SX1268 *) lora)->setDio1Action(setFlag);
+              state = ((SX1268 *) lora)->setSyncWord(m.fsw, m.swSize);
+              break;
+          case 1: // SX127x
+              state = ((SX1278 *) lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev,
+                                                  m.bw,
+                                                  m.power, m.preambleLength, (m.OOK != 255));
+              ((SX1278 *) lora)->setDataShaping(m.OOK);
+              ((SX1278 *) lora)->startReceive();
+              ((SX1278 *) lora)->setDio0Action(setFlag);
+              ((SX1278 *) lora)->setSyncWord(m.fsw, m.swSize);
+              break;
+          case 2: // SX128x
+              state = ((SX1280 *) lora)->beginGFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev,
+                                                   m.power, m.preambleLength);
+              ((SX1280 *) lora)->setDataShaping(m.OOK);
+              ((SX1280 *) lora)->startReceive();
+              ((SX1280 *) lora)->setDio1Action(setFlag);
+              ((SX1280 *) lora)->setSyncWord(m.fsw, m.swSize);
+              //??//state = ((SX1280 *) lora)->setSyncWord(m.fsw, m.swSize);
+              break;
+          default: // Undefined
+              Log::console(PSTR("Board Type in Undefined ... "));
+      }
   }
 
   // registers
@@ -162,21 +242,47 @@ int16_t Radio::begin()
   // set the function that will be called
   // when new packet is received
   // attach the ISR to radio interrupt
-  if (board.L_SX127X)
-  {
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+//  if (board.L_SX127X)
+//  {
+//    ((SX1278 *)lora)->setDio0Action(setFlag);
+//  }
+//  else
+//  {
+//    ((SX1268 *)lora)->setDio1Action(setFlag);
+//  }
+    switch (board.L_SX127X) {
+        case 0: // SX126x
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   // start listening for LoRa packets
   Log::console(PSTR("[SX12x8] Starting to listen to %s"), m.satellite);
-  if (board.L_SX127X)
-    state = ((SX1278 *)lora)->startReceive();
-  else
-    state = ((SX1268 *)lora)->startReceive();
+//  if (board.L_SX127X)
+//    state = ((SX1278 *)lora)->startReceive();
+//  else
+//    state = ((SX1268 *)lora)->startReceive();
+    switch (board.L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->startReceive();
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->startReceive();
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->startReceive();
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   if (state == ERR_NONE)
   {
@@ -216,10 +322,23 @@ void Radio::disableInterrupt()
 void Radio::startRx()
 {
   // put module back to listen mode
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    ((SX1278 *)lora)->startReceive();
-  else
-    ((SX1268 *)lora)->startReceive();
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    ((SX1278 *)lora)->startReceive();
+//  else
+//    ((SX1268 *)lora)->startReceive();
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            ((SX1268 *) lora)->startReceive();
+            break;
+        case 1: // SX127x
+            ((SX1278 *) lora)->startReceive();
+            break;
+        case 2: // SX128x
+            ((SX1280 *) lora)->startReceive();
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   // we're ready to receive more packets,
   // enable interrupt service routine
@@ -237,20 +356,48 @@ int16_t Radio::sendTx(uint8_t *data, size_t length)
 
   // send data
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    SX1278 *l = (SX1278 *)lora;
-    state = l->transmit(data, length);
-    l->setDio0Action(setFlag);
-    l->startReceive();
-  }
-  else
-  {
-    SX1268 *l = (SX1268 *)lora;
-    state = l->transmit(data, length);
-    l->setDio1Action(setFlag);
-    l->startReceive();
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    SX1278 *l = (SX1278 *)lora;
+//    state = l->transmit(data, length);
+//    l->setDio0Action(setFlag);
+//    l->startReceive();
+//  }
+//  else
+//  {
+//    SX1268 *l = (SX1268 *)lora;
+//    state = l->transmit(data, length);
+//    l->setDio1Action(setFlag);
+//    l->startReceive();
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+        {
+            SX1268 *l = (SX1268 *) lora;
+            state = l->transmit(data, length);
+            l->setDio1Action(setFlag);
+            l->startReceive();
+        }
+            break;
+        case 1: // SX127x
+        {
+            SX1278 *l = (SX1278 *) lora;
+            state = l->transmit(data, length);
+            l->setDio0Action(setFlag);
+            l->startReceive();
+        }
+            break;
+        case 2: // SX128x
+        {
+            SX1280 *l = (SX1280 *) lora;
+            state = l->transmit(data, length);
+            l->setDio1Action(setFlag);
+            l->startReceive();
+        }
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   enableInterrupt();
   return state;
@@ -281,25 +428,61 @@ uint8_t Radio::listen()
   PacketInfo newPacketInfo;
   status.lastPacketInfo.crc_error = 0;
   // read received data
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    SX1278 *l = (SX1278 *)lora;
-    respLen = l->getPacketLength();
-    respFrame = new uint8_t[respLen];
-    state = l->readData(respFrame, respLen);
-    newPacketInfo.rssi = l->getRSSI();
-    newPacketInfo.snr = l->getSNR();
-    newPacketInfo.frequencyerror = l->getFrequencyError();
-  }
-  else
-  {
-    SX1268 *l = (SX1268 *)lora;
-    respLen = l->getPacketLength();
-    respFrame = new uint8_t[respLen];
-    state = l->readData(respFrame, respLen);
-    newPacketInfo.rssi = l->getRSSI();
-    newPacketInfo.snr = l->getSNR();
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    SX1278 *l = (SX1278 *)lora;
+//    respLen = l->getPacketLength();
+//    respFrame = new uint8_t[respLen];
+//    state = l->readData(respFrame, respLen);
+//    newPacketInfo.rssi = l->getRSSI();
+//    newPacketInfo.snr = l->getSNR();
+//    newPacketInfo.frequencyerror = l->getFrequencyError();
+//  }
+//  else
+//  {
+//    SX1268 *l = (SX1268 *)lora;
+//    respLen = l->getPacketLength();
+//    respFrame = new uint8_t[respLen];
+//    state = l->readData(respFrame, respLen);
+//    newPacketInfo.rssi = l->getRSSI();
+//    newPacketInfo.snr = l->getSNR();
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+        {
+            SX1268 *l = (SX1268 *) lora;
+            respLen = l->getPacketLength();
+            respFrame = new uint8_t[respLen];
+            state = l->readData(respFrame, respLen);
+            newPacketInfo.rssi = l->getRSSI();
+            newPacketInfo.snr = l->getSNR();
+        }
+            break;
+        case 1: // SX127x
+        {
+            SX1278 *l = (SX1278 *) lora;
+            respLen = l->getPacketLength();
+            respFrame = new uint8_t[respLen];
+            state = l->readData(respFrame, respLen);
+            newPacketInfo.rssi = l->getRSSI();
+            newPacketInfo.snr = l->getSNR();
+            newPacketInfo.frequencyerror = l->getFrequencyError();
+        }
+            break;
+        case 2: // SX128x
+        {
+            SX1280 *l = (SX1280 *) lora;
+            respLen = l->getPacketLength();
+            respFrame = new uint8_t[respLen];
+            state = l->readData(respFrame, respLen);
+            newPacketInfo.rssi = l->getRSSI();
+            newPacketInfo.snr = l->getSNR();
+            //newPacketInfo.frequencyerror = l->getFrequencyError();
+        }
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   // check if the packet info is exactly the same as the last one
   if (newPacketInfo.rssi == status.lastPacketInfo.rssi &&
@@ -466,18 +649,37 @@ int16_t Radio::remote_freq(char *payload, size_t payload_len)
   Log::console(PSTR("Set Frequency: %.3f MHz"), frequency);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    ((SX1278 *)lora)->sleep(); // sleep mandatory if FastHop isn't ON.
-    state = ((SX1278 *)lora)->setFrequency(frequency + status.modeminfo.freqOffset);
-    ((SX1278 *)lora)->startReceive();
-  }
-  else
-  {
-    ((SX1268 *)lora)->sleep();
-    state = ((SX1268 *)lora)->setFrequency(frequency + status.modeminfo.freqOffset);
-    ((SX1268 *)lora)->startReceive();
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    ((SX1278 *)lora)->sleep(); // sleep mandatory if FastHop isn't ON.
+//    state = ((SX1278 *)lora)->setFrequency(frequency + status.modeminfo.freqOffset);
+//    ((SX1278 *)lora)->startReceive();
+//  }
+//  else
+//  {
+//    ((SX1268 *)lora)->sleep();
+//    state = ((SX1268 *)lora)->setFrequency(frequency + status.modeminfo.freqOffset);
+//    ((SX1268 *)lora)->startReceive();
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            ((SX1268 *) lora)->sleep();
+            state = ((SX1268 *) lora)->setFrequency(frequency + status.modeminfo.freqOffset);
+            ((SX1268 *) lora)->startReceive();
+            break;
+        case 1: // SX127x
+            ((SX1278 *) lora)->sleep(); // sleep mandatory if FastHop isn't ON.
+            state = ((SX1278 *) lora)->setFrequency(frequency + status.modeminfo.freqOffset);
+            ((SX1278 *) lora)->startReceive();
+            break;
+        case 2: // SX128x
+            ((SX1280 *) lora)->sleep(); // sleep mandatory if FastHop isn't ON.
+            state = ((SX1280 *) lora)->setFrequency(frequency + status.modeminfo.freqOffset);
+            ((SX1280 *) lora)->startReceive();
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   if (state == ERR_NONE)
@@ -492,18 +694,37 @@ int16_t Radio::remote_bw(char *payload, size_t payload_len)
   Log::console(PSTR("Set bandwidth: %.3f MHz"), bw);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->setBandwidth(bw);
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->setBandwidth(bw);
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    state = ((SX1278 *)lora)->setBandwidth(bw);
+//    ((SX1278 *)lora)->startReceive();
+//    ((SX1278 *)lora)->setDio0Action(setFlag);
+//  }
+//  else
+//  {
+//    state = ((SX1268 *)lora)->setBandwidth(bw);
+//    ((SX1268 *)lora)->startReceive();
+//    ((SX1268 *)lora)->setDio1Action(setFlag);
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setBandwidth(bw);
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setBandwidth(bw);
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setBandwidth(bw);
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   if (state == ERR_NONE)
@@ -518,18 +739,37 @@ int16_t Radio::remote_sf(char *payload, size_t payload_len)
   Log::console(PSTR("Set spreading factor: %u"), sf);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->setSpreadingFactor(sf);
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->setSpreadingFactor(sf);
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    state = ((SX1278 *)lora)->setSpreadingFactor(sf);
+//    ((SX1278 *)lora)->startReceive();
+//    ((SX1278 *)lora)->setDio0Action(setFlag);
+//  }
+//  else
+//  {
+//    state = ((SX1268 *)lora)->setSpreadingFactor(sf);
+//    ((SX1268 *)lora)->startReceive();
+//    ((SX1268 *)lora)->setDio1Action(setFlag);
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setSpreadingFactor(sf);
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setSpreadingFactor(sf);
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setSpreadingFactor(sf);
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
 
@@ -545,18 +785,25 @@ int16_t Radio::remote_cr(char *payload, size_t payload_len)
   Log::console(PSTR("Set coding rate: %u"), cr);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->setCodingRate(cr);
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->setCodingRate(cr);
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setCodingRate(cr);
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setCodingRate(cr);
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setCodingRate(cr);
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
 
@@ -572,18 +819,25 @@ int16_t Radio::remote_crc(char *payload, size_t payload_len)
   Log::console(PSTR("Set CRC: %s"), crc ? F("ON") : F("OFF"));
   int16_t state = 0;
 
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->setCRC(crc);
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->setCRC(crc);
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setCRC(crc);
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setCRC(crc);
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setCRC(crc);
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   return state;
@@ -597,10 +851,24 @@ int16_t Radio::remote_lsw(char *payload, size_t payload_len)
   Log::console(PSTR("Set lsw: %s"), strHex);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    state = ((SX1278 *)lora)->setSyncWord(sw);
-  else
-    state = ((SX1268 *)lora)->setSyncWord(sw, 0x44);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    state = ((SX1278 *)lora)->setSyncWord(sw);
+//  else
+//    state = ((SX1268 *)lora)->setSyncWord(sw, 0x44);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setSyncWord(sw, 0x44);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setSyncWord(sw);
+            break;
+        case 2: // SX128x
+            // NEED THE CORRECT VALUES for setSyncWord
+            //    state = ((SX1280 *) lora)->setSyncWord(sw, 1);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   return state;
@@ -612,18 +880,37 @@ int16_t Radio::remote_fldro(char *payload, size_t payload_len)
   Log::console(PSTR("Set ForceLDRO: %s"), ldro ? F("ON") : F("OFF"));
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->forceLDRO(ldro);
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->forceLDRO(ldro);
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    state = ((SX1278 *)lora)->forceLDRO(ldro);
+//    ((SX1278 *)lora)->startReceive();
+//    ((SX1278 *)lora)->setDio0Action(setFlag);
+//  }
+//  else
+//  {
+//    state = ((SX1268 *)lora)->forceLDRO(ldro);
+//    ((SX1268 *)lora)->startReceive();
+//    ((SX1268 *)lora)->setDio1Action(setFlag);
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->forceLDRO(ldro);
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->forceLDRO(ldro);
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            //state = ((SX1280 *) lora)->forceLDRO(ldro);
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
 
@@ -643,18 +930,37 @@ int16_t Radio::remote_aldro(char *payload, size_t payload_len)
   Log::console(PSTR("Set AutoLDRO "));
   int16_t state = 0;
 
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->autoLDRO();
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->autoLDRO();
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    state = ((SX1278 *)lora)->autoLDRO();
+//    ((SX1278 *)lora)->startReceive();
+//    ((SX1278 *)lora)->setDio0Action(setFlag);
+//  }
+//  else
+//  {
+//    state = ((SX1268 *)lora)->autoLDRO();
+//    ((SX1268 *)lora)->startReceive();
+//    ((SX1268 *)lora)->setDio1Action(setFlag);
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->autoLDRO();
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->autoLDRO();
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            //state = ((SX1280 *) lora)->autoLDRO();
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   return state;
@@ -666,18 +972,37 @@ int16_t Radio::remote_pl(char *payload, size_t payload_len)
   Log::console(PSTR("Set Preamble %u"), pl);
   int16_t state = 0;
 
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->setPreambleLength(pl);
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->setPreambleLength(pl);
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    state = ((SX1278 *)lora)->setPreambleLength(pl);
+//    ((SX1278 *)lora)->startReceive();
+//    ((SX1278 *)lora)->setDio0Action(setFlag);
+//  }
+//  else
+//  {
+//    state = ((SX1268 *)lora)->setPreambleLength(pl);
+//    ((SX1268 *)lora)->startReceive();
+//    ((SX1268 *)lora)->setDio1Action(setFlag);
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setPreambleLength(pl);
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setPreambleLength(pl);
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setPreambleLength(pl);
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   if (state == ERR_NONE)
@@ -709,19 +1034,42 @@ int16_t Radio::remote_begin_lora(char *payload, size_t payload_len)
   Log::console(PSTR("Set Power: %d\nSet C limit: %u\nSet Preamble: %u\nSet Gain: %u"), power, current_limit, preambleLength, gain);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    ((SX1278 *)lora)->sleep(); // sleep mandatory if FastHop isn't ON.
-    state = ((SX1278 *)lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord78, power, preambleLength, gain);
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord68, power, preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    ((SX1278 *)lora)->sleep(); // sleep mandatory if FastHop isn't ON.
+//    state = ((SX1278 *)lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord78, power, preambleLength, gain);
+//    ((SX1278 *)lora)->startReceive();
+//    ((SX1278 *)lora)->setDio0Action(setFlag);
+//  }
+//  else
+//  {
+//    state = ((SX1268 *)lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord68, power, preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
+//    ((SX1268 *)lora)->startReceive();
+//    ((SX1268 *)lora)->setDio1Action(setFlag);
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord68, power,
+                                             preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            ((SX1278 *) lora)->sleep(); // sleep mandatory if FastHop isn't ON.
+            state = ((SX1278 *) lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord78, power,
+                                             preambleLength, gain);
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            ((SX1280 *) lora)->sleep(); // sleep mandatory if FastHop isn't ON.
+            state = ((SX1280 *) lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, power, preambleLength);
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   if (state == ERR_NONE)
@@ -755,20 +1103,45 @@ int16_t Radio::remote_begin_fsk(char *payload, size_t payload_len)
   Log::console(PSTR("Set Current limit: %u\nSet Preamble Length: %u\nOOK Modulation %s\nSet datashaping %u"), currentlimit, preambleLength, (ook != 255) ? F("ON") : F("OFF"), ook);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power, preambleLength, (ook != 255));
-    ((SX1278 *)lora)->setDataShaping(ook);
-    ((SX1278 *)lora)->startReceive();
-    ((SX1278 *)lora)->setDio0Action(setFlag);
-  }
-  else
-  {
-    state = ((SX1268 *)lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power, preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
-    ((SX1268 *)lora)->setDataShaping(ook);
-    ((SX1268 *)lora)->startReceive();
-    ((SX1268 *)lora)->setDio1Action(setFlag);
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    state = ((SX1278 *)lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power, preambleLength, (ook != 255));
+//    ((SX1278 *)lora)->setDataShaping(ook);
+//    ((SX1278 *)lora)->startReceive();
+//    ((SX1278 *)lora)->setDio0Action(setFlag);
+//  }
+//  else
+//  {
+//    state = ((SX1268 *)lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power, preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
+//    ((SX1268 *)lora)->setDataShaping(ook);
+//    ((SX1268 *)lora)->startReceive();
+//    ((SX1268 *)lora)->setDio1Action(setFlag);
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power,
+                                                preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
+            ((SX1268 *) lora)->setDataShaping(ook);
+            ((SX1268 *) lora)->startReceive();
+            ((SX1268 *) lora)->setDio1Action(setFlag);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power,
+                                                preambleLength, (ook != 255));
+            ((SX1278 *) lora)->setDataShaping(ook);
+            ((SX1278 *) lora)->startReceive();
+            ((SX1278 *) lora)->setDio0Action(setFlag);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->beginGFSK(freq + status.modeminfo.freqOffset, br, freqDev, power,
+                                                 preambleLength);
+            ((SX1280 *) lora)->setDataShaping(ook);
+            ((SX1280 *) lora)->startReceive();
+            ((SX1280 *) lora)->setDio1Action(setFlag);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
   readState(state);
 
   if (state == ERR_NONE)
@@ -792,10 +1165,23 @@ int16_t Radio::remote_br(char *payload, size_t payload_len)
   Log::console(PSTR("Set FSK Bit rate: %u"), br);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    state = ((SX1278 *)lora)->setBitRate(br);
-  else
-    state = ((SX1268 *)lora)->setBitRate(br);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    state = ((SX1278 *)lora)->setBitRate(br);
+//  else
+//    state = ((SX1268 *)lora)->setBitRate(br);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setBitRate(br);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setBitRate(br);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setBitRate(br);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   if (state == ERR_NONE)
@@ -810,10 +1196,23 @@ int16_t Radio::remote_fd(char *payload, size_t payload_len)
   Log::console(PSTR("Set FSK Frequency Dev.: %u"), fd);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    state = ((SX1278 *)lora)->setFrequencyDeviation(fd);
-  else
-    state = ((SX1268 *)lora)->setFrequencyDeviation(fd);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    state = ((SX1278 *)lora)->setFrequencyDeviation(fd);
+//  else
+//    state = ((SX1268 *)lora)->setFrequencyDeviation(fd);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setFrequencyDeviation(fd);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setFrequencyDeviation(fd);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setFrequencyDeviation(fd);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   if (state == ERR_NONE)
@@ -828,10 +1227,23 @@ int16_t Radio::remote_fbw(char *payload, size_t payload_len)
   Log::console(PSTR("Set FSK bandwidth: %.3f kHz"), frequency);
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    state = ((SX1278 *)lora)->setRxBandwidth(frequency);
-  else
-    state = ((SX1268 *)lora)->setRxBandwidth(frequency);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    state = ((SX1278 *)lora)->setRxBandwidth(frequency);
+//  else
+//    state = ((SX1268 *)lora)->setRxBandwidth(frequency);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setRxBandwidth(frequency);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setRxBandwidth(frequency);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setBandwidth(frequency);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   if (state == ERR_NONE)
@@ -861,10 +1273,23 @@ int16_t Radio::remote_fsw(char *payload, size_t payload_len)
   }
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    state = ((SX1278 *)lora)->setSyncWord(syncWord, synnwordsize);
-  else
-    state = ((SX1268 *)lora)->setSyncWord(syncWord, synnwordsize);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    state = ((SX1278 *)lora)->setSyncWord(syncWord, synnwordsize);
+//  else
+//    state = ((SX1268 *)lora)->setSyncWord(syncWord, synnwordsize);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->setSyncWord(syncWord, synnwordsize);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setSyncWord(syncWord, synnwordsize);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->setSyncWord(syncWord, synnwordsize);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   return state;
@@ -881,20 +1306,46 @@ int16_t Radio::remote_fook(char *payload, size_t payload_len)
   Log::console(PSTR("Set OOK datashaping: %u"), ook_shape);
 
   int state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-  {
-    state = ((SX1278 *)lora)->setOOK(enableOOK);
-  }
-  else
-  {
-    Log::error(PSTR("OOK not supported by the selected lora module!"));
-    return -1;
-  }
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//  {
+//    state = ((SX1278 *)lora)->setOOK(enableOOK);
+//  }
+//  else
+//  {
+//    Log::error(PSTR("OOK not supported by the selected lora module!"));
+//    return -1;
+//  }
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            Log::error(PSTR("OOK not supported by the selected lora module!"));
+            return -1;
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setOOK(enableOOK);
+            break;
+        case 2: // SX128x
+            Log::error(PSTR("OOK not supported by the selected lora module!"));
+            return -1;
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
 
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    state = ((SX1278 *)lora)->setDataShapingOOK(ook_shape);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    state = ((SX1278 *)lora)->setDataShapingOOK(ook_shape);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->setDataShapingOOK(ook_shape);
+            break;
+        case 2: // SX128x
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   readState(state);
   return state;
@@ -908,10 +1359,23 @@ void Radio::remote_SPIwriteRegister(char *payload, size_t payload_len)
   uint8_t data = doc[1];
   Log::console(PSTR("REG ID: 0x%x to 0x%x"), reg, data);
 
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    ((SX1278 *)lora)->_mod->SPIwriteRegister(reg, data);
-  //  else
-  //   ((SX1268*)lora)->_mod->SPIwriteRegister(reg,data);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    ((SX1278 *)lora)->_mod->SPIwriteRegister(reg, data);
+//  //  else
+//  //   ((SX1268*)lora)->_mod->SPIwriteRegister(reg,data);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            ((SX1268 *) lora)->_mod->SPIwriteRegister(reg, data);
+            break;
+        case 1: // SX127x
+            ((SX1278 *) lora)->_mod->SPIwriteRegister(reg, data);
+            break;
+        case 2: // SX128x
+            ((SX1280 *) lora)->_mod->SPIwriteRegister(reg, data);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 }
 
 int16_t Radio::remote_SPIreadRegister(char *payload, size_t payload_len)
@@ -920,10 +1384,23 @@ int16_t Radio::remote_SPIreadRegister(char *payload, size_t payload_len)
   uint8_t data = 0;
 
   int16_t state = 0;
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    data = ((SX1278 *)lora)->_mod->SPIreadRegister(reg);
-  // else
-  //   data = ((SX1268*)lora)->_mod->SPIreadRegister(reg);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    data = ((SX1278 *)lora)->_mod->SPIreadRegister(reg);
+//  // else
+//  //   data = ((SX1268*)lora)->_mod->SPIreadRegister(reg);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            data = ((SX1268 *) lora)->_mod->SPIreadRegister(reg);
+            break;
+        case 1: // SX127x
+            data = ((SX1278 *) lora)->_mod->SPIreadRegister(reg);
+            break;
+        case 2: // SX128x
+            data = ((SX1280 *) lora)->_mod->SPIreadRegister(reg);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
   Log::console(PSTR("REG ID: 0x%x HEX : 0x%x BIN : %b"), reg, data, data);
 
@@ -957,10 +1434,23 @@ int16_t Radio::remote_SPIsetRegValue(char *payload, size_t payload_len)
 
   int16_t state = 0;
 
-  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-    state = ((SX1278 *)lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
-  else
-    //   state = ((SX1268*)lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
+//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
+//    state = ((SX1278 *)lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
+//  else
+//    //   state = ((SX1268*)lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268 *) lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
+            break;
+        case 1: // SX127x
+            state = ((SX1278 *) lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
+            break;
+        case 2: // SX128x
+            state = ((SX1280 *) lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
 
     readState(state);
   return state;

--- a/tinyGS/src/Radio/Radio.cpp
+++ b/tinyGS/src/Radio/Radio.cpp
@@ -74,14 +74,6 @@ void Radio::init()
 
   spi.begin(board.L_SCK, board.L_MISO, board.L_MOSI, board.L_NSS);
 
-//  if (board.L_SX127X)
-//  {
-//    lora = new SX1278(new Module(board.L_NSS, board.L_DI00, board.L_DI01, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
-//  }
-//  else
-//  {
-//    lora = new SX1268(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
-//  }
     switch (board.L_SX127X) {
         case 0: // SX126x
             lora = new SX1268(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi,
@@ -112,26 +104,6 @@ int16_t Radio::begin()
 
   if (m.modem_mode == "LoRa")
   {
-//    if (board.L_SX127X)
-//    {
-//      state = ((SX1278 *)lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw, m.power, m.preambleLength, m.gain);
-//      if (m.fldro == 2)
-//        ((SX1278 *)lora)->autoLDRO();
-//      else
-//        ((SX1278 *)lora)->forceLDRO(m.fldro);
-//
-//      ((SX1278 *)lora)->setCRC(m.crc);
-//    }
-//    else
-//    {
-//      state = ((SX1268 *)lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw, m.power, m.preambleLength, board.L_TCXO_V);
-//      if (m.fldro == 2)
-//        ((SX1268 *)lora)->autoLDRO();
-//      else
-//        ((SX1268 *)lora)->forceLDRO(m.fldro);
-//
-//      ((SX1268 *)lora)->setCRC(m.crc);
-//    }
       switch (board.L_SX127X) {
           case 0: // SX126x
               state = ((SX1268 *) lora)->begin(m.frequency + status.modeminfo.freqOffset, m.bw, m.sf, m.cr, m.sw,
@@ -166,22 +138,6 @@ int16_t Radio::begin()
   }
   else
   {
-//    if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    {
-//      state = ((SX1278 *)lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev, m.bw, m.power, m.preambleLength, (m.OOK != 255));
-//      ((SX1278 *)lora)->setDataShaping(m.OOK);
-//      ((SX1278 *)lora)->startReceive();
-//      ((SX1278 *)lora)->setDio0Action(setFlag);
-//      ((SX1278 *)lora)->setSyncWord(m.fsw, m.swSize);
-//    }
-//    else
-//    {
-//      state = ((SX1268 *)lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev, m.bw, m.power, m.preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
-//      ((SX1268 *)lora)->setDataShaping(m.OOK);
-//      ((SX1268 *)lora)->startReceive();
-//      ((SX1268 *)lora)->setDio1Action(setFlag);
-//      state = ((SX1268 *)lora)->setSyncWord(m.fsw, m.swSize);
-//    }
       switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
           case 0: // SX126x
               state = ((SX1268 *) lora)->beginFSK(m.frequency + status.modeminfo.freqOffset, m.bitrate, m.freqDev,
@@ -223,11 +179,20 @@ int16_t Radio::begin()
     uint16_t regValue = reg["ref"];
     uint32_t regMask = reg["mask"];
 
-    if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-      state = ((SX1278*)lora)->_mod->SPIsetRegValue((regValue>>8)&0x0F, regValue&0x0F, (regMask>>16)&0x0F, (regMask>>8)&0x0F, regMask&0x0F);
-   // else
-   //   state = ((SX1268*)lora)->_mod->SPIsetRegValue((regValue>>8)&0x0F, regValue&0x0F, (regMask>>16)&0x0F, (regMask>>8)&0x0F, regMask&0x0F);
-  }*/
+    switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
+        case 0: // SX126x
+            state = ((SX1268*)lora)->_mod->SPIsetRegValue((regValue>>8)&0x0F, regValue&0x0F, (regMask>>16)&0x0F, (regMask>>8)&0x0F, regMask&0x0F);
+            break;
+        case 1: // SX127x
+           state = ((SX1278*)lora)->_mod->SPIsetRegValue((regValue>>8)&0x0F, regValue&0x0F, (regMask>>16)&0x0F, (regMask>>8)&0x0F, regMask&0x0F);
+            break;
+        case 2: // SX128x
+           state = ((SX1280*)lora)->_mod->SPIsetRegValue((regValue>>8)&0x0F, regValue&0x0F, (regMask>>16)&0x0F, (regMask>>8)&0x0F, regMask&0x0F);
+            break;
+        default: // Undefined
+            Log::console(PSTR("Board Type in Undefined ... "));
+    }
+   */
 
   if (state == ERR_NONE)
   {
@@ -242,14 +207,6 @@ int16_t Radio::begin()
   // set the function that will be called
   // when new packet is received
   // attach the ISR to radio interrupt
-//  if (board.L_SX127X)
-//  {
-//    ((SX1278 *)lora)->setDio0Action(setFlag);
-//  }
-//  else
-//  {
-//    ((SX1268 *)lora)->setDio1Action(setFlag);
-//  }
     switch (board.L_SX127X) {
         case 0: // SX126x
             ((SX1268 *) lora)->setDio1Action(setFlag);
@@ -266,10 +223,6 @@ int16_t Radio::begin()
 
   // start listening for LoRa packets
   Log::console(PSTR("[SX12x8] Starting to listen to %s"), m.satellite);
-//  if (board.L_SX127X)
-//    state = ((SX1278 *)lora)->startReceive();
-//  else
-//    state = ((SX1268 *)lora)->startReceive();
     switch (board.L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->startReceive();
@@ -322,10 +275,6 @@ void Radio::disableInterrupt()
 void Radio::startRx()
 {
   // put module back to listen mode
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    ((SX1278 *)lora)->startReceive();
-//  else
-//    ((SX1268 *)lora)->startReceive();
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             ((SX1268 *) lora)->startReceive();
@@ -356,20 +305,6 @@ int16_t Radio::sendTx(uint8_t *data, size_t length)
 
   // send data
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    SX1278 *l = (SX1278 *)lora;
-//    state = l->transmit(data, length);
-//    l->setDio0Action(setFlag);
-//    l->startReceive();
-//  }
-//  else
-//  {
-//    SX1268 *l = (SX1268 *)lora;
-//    state = l->transmit(data, length);
-//    l->setDio1Action(setFlag);
-//    l->startReceive();
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
         {
@@ -428,25 +363,6 @@ uint8_t Radio::listen()
   PacketInfo newPacketInfo;
   status.lastPacketInfo.crc_error = 0;
   // read received data
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    SX1278 *l = (SX1278 *)lora;
-//    respLen = l->getPacketLength();
-//    respFrame = new uint8_t[respLen];
-//    state = l->readData(respFrame, respLen);
-//    newPacketInfo.rssi = l->getRSSI();
-//    newPacketInfo.snr = l->getSNR();
-//    newPacketInfo.frequencyerror = l->getFrequencyError();
-//  }
-//  else
-//  {
-//    SX1268 *l = (SX1268 *)lora;
-//    respLen = l->getPacketLength();
-//    respFrame = new uint8_t[respLen];
-//    state = l->readData(respFrame, respLen);
-//    newPacketInfo.rssi = l->getRSSI();
-//    newPacketInfo.snr = l->getSNR();
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
         {
@@ -649,18 +565,6 @@ int16_t Radio::remote_freq(char *payload, size_t payload_len)
   Log::console(PSTR("Set Frequency: %.3f MHz"), frequency);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    ((SX1278 *)lora)->sleep(); // sleep mandatory if FastHop isn't ON.
-//    state = ((SX1278 *)lora)->setFrequency(frequency + status.modeminfo.freqOffset);
-//    ((SX1278 *)lora)->startReceive();
-//  }
-//  else
-//  {
-//    ((SX1268 *)lora)->sleep();
-//    state = ((SX1268 *)lora)->setFrequency(frequency + status.modeminfo.freqOffset);
-//    ((SX1268 *)lora)->startReceive();
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             ((SX1268 *) lora)->sleep();
@@ -694,18 +598,6 @@ int16_t Radio::remote_bw(char *payload, size_t payload_len)
   Log::console(PSTR("Set bandwidth: %.3f MHz"), bw);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    state = ((SX1278 *)lora)->setBandwidth(bw);
-//    ((SX1278 *)lora)->startReceive();
-//    ((SX1278 *)lora)->setDio0Action(setFlag);
-//  }
-//  else
-//  {
-//    state = ((SX1268 *)lora)->setBandwidth(bw);
-//    ((SX1268 *)lora)->startReceive();
-//    ((SX1268 *)lora)->setDio1Action(setFlag);
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->setBandwidth(bw);
@@ -739,18 +631,6 @@ int16_t Radio::remote_sf(char *payload, size_t payload_len)
   Log::console(PSTR("Set spreading factor: %u"), sf);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    state = ((SX1278 *)lora)->setSpreadingFactor(sf);
-//    ((SX1278 *)lora)->startReceive();
-//    ((SX1278 *)lora)->setDio0Action(setFlag);
-//  }
-//  else
-//  {
-//    state = ((SX1268 *)lora)->setSpreadingFactor(sf);
-//    ((SX1268 *)lora)->startReceive();
-//    ((SX1268 *)lora)->setDio1Action(setFlag);
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->setSpreadingFactor(sf);
@@ -851,10 +731,6 @@ int16_t Radio::remote_lsw(char *payload, size_t payload_len)
   Log::console(PSTR("Set lsw: %s"), strHex);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    state = ((SX1278 *)lora)->setSyncWord(sw);
-//  else
-//    state = ((SX1268 *)lora)->setSyncWord(sw, 0x44);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->setSyncWord(sw, 0x44);
@@ -880,18 +756,6 @@ int16_t Radio::remote_fldro(char *payload, size_t payload_len)
   Log::console(PSTR("Set ForceLDRO: %s"), ldro ? F("ON") : F("OFF"));
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    state = ((SX1278 *)lora)->forceLDRO(ldro);
-//    ((SX1278 *)lora)->startReceive();
-//    ((SX1278 *)lora)->setDio0Action(setFlag);
-//  }
-//  else
-//  {
-//    state = ((SX1268 *)lora)->forceLDRO(ldro);
-//    ((SX1268 *)lora)->startReceive();
-//    ((SX1268 *)lora)->setDio1Action(setFlag);
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->forceLDRO(ldro);
@@ -930,18 +794,6 @@ int16_t Radio::remote_aldro(char *payload, size_t payload_len)
   Log::console(PSTR("Set AutoLDRO "));
   int16_t state = 0;
 
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    state = ((SX1278 *)lora)->autoLDRO();
-//    ((SX1278 *)lora)->startReceive();
-//    ((SX1278 *)lora)->setDio0Action(setFlag);
-//  }
-//  else
-//  {
-//    state = ((SX1268 *)lora)->autoLDRO();
-//    ((SX1268 *)lora)->startReceive();
-//    ((SX1268 *)lora)->setDio1Action(setFlag);
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->autoLDRO();
@@ -972,18 +824,6 @@ int16_t Radio::remote_pl(char *payload, size_t payload_len)
   Log::console(PSTR("Set Preamble %u"), pl);
   int16_t state = 0;
 
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    state = ((SX1278 *)lora)->setPreambleLength(pl);
-//    ((SX1278 *)lora)->startReceive();
-//    ((SX1278 *)lora)->setDio0Action(setFlag);
-//  }
-//  else
-//  {
-//    state = ((SX1268 *)lora)->setPreambleLength(pl);
-//    ((SX1268 *)lora)->startReceive();
-//    ((SX1268 *)lora)->setDio1Action(setFlag);
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->setPreambleLength(pl);
@@ -1034,19 +874,6 @@ int16_t Radio::remote_begin_lora(char *payload, size_t payload_len)
   Log::console(PSTR("Set Power: %d\nSet C limit: %u\nSet Preamble: %u\nSet Gain: %u"), power, current_limit, preambleLength, gain);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    ((SX1278 *)lora)->sleep(); // sleep mandatory if FastHop isn't ON.
-//    state = ((SX1278 *)lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord78, power, preambleLength, gain);
-//    ((SX1278 *)lora)->startReceive();
-//    ((SX1278 *)lora)->setDio0Action(setFlag);
-//  }
-//  else
-//  {
-//    state = ((SX1268 *)lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord68, power, preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
-//    ((SX1268 *)lora)->startReceive();
-//    ((SX1268 *)lora)->setDio1Action(setFlag);
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->begin(freq + status.modeminfo.freqOffset, bw, sf, cr, syncWord68, power,
@@ -1103,20 +930,6 @@ int16_t Radio::remote_begin_fsk(char *payload, size_t payload_len)
   Log::console(PSTR("Set Current limit: %u\nSet Preamble Length: %u\nOOK Modulation %s\nSet datashaping %u"), currentlimit, preambleLength, (ook != 255) ? F("ON") : F("OFF"), ook);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    state = ((SX1278 *)lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power, preambleLength, (ook != 255));
-//    ((SX1278 *)lora)->setDataShaping(ook);
-//    ((SX1278 *)lora)->startReceive();
-//    ((SX1278 *)lora)->setDio0Action(setFlag);
-//  }
-//  else
-//  {
-//    state = ((SX1268 *)lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power, preambleLength, ConfigManager::getInstance().getBoardConfig().L_TCXO_V);
-//    ((SX1268 *)lora)->setDataShaping(ook);
-//    ((SX1268 *)lora)->startReceive();
-//    ((SX1268 *)lora)->setDio1Action(setFlag);
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->beginFSK(freq + status.modeminfo.freqOffset, br, freqDev, rxBw, power,
@@ -1165,10 +978,6 @@ int16_t Radio::remote_br(char *payload, size_t payload_len)
   Log::console(PSTR("Set FSK Bit rate: %u"), br);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    state = ((SX1278 *)lora)->setBitRate(br);
-//  else
-//    state = ((SX1268 *)lora)->setBitRate(br);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->setBitRate(br);
@@ -1196,10 +1005,6 @@ int16_t Radio::remote_fd(char *payload, size_t payload_len)
   Log::console(PSTR("Set FSK Frequency Dev.: %u"), fd);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    state = ((SX1278 *)lora)->setFrequencyDeviation(fd);
-//  else
-//    state = ((SX1268 *)lora)->setFrequencyDeviation(fd);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->setFrequencyDeviation(fd);
@@ -1227,10 +1032,6 @@ int16_t Radio::remote_fbw(char *payload, size_t payload_len)
   Log::console(PSTR("Set FSK bandwidth: %.3f kHz"), frequency);
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    state = ((SX1278 *)lora)->setRxBandwidth(frequency);
-//  else
-//    state = ((SX1268 *)lora)->setRxBandwidth(frequency);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->setRxBandwidth(frequency);
@@ -1273,10 +1074,6 @@ int16_t Radio::remote_fsw(char *payload, size_t payload_len)
   }
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    state = ((SX1278 *)lora)->setSyncWord(syncWord, synnwordsize);
-//  else
-//    state = ((SX1268 *)lora)->setSyncWord(syncWord, synnwordsize);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->setSyncWord(syncWord, synnwordsize);
@@ -1306,15 +1103,6 @@ int16_t Radio::remote_fook(char *payload, size_t payload_len)
   Log::console(PSTR("Set OOK datashaping: %u"), ook_shape);
 
   int state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//  {
-//    state = ((SX1278 *)lora)->setOOK(enableOOK);
-//  }
-//  else
-//  {
-//    Log::error(PSTR("OOK not supported by the selected lora module!"));
-//    return -1;
-//  }
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             Log::error(PSTR("OOK not supported by the selected lora module!"));
@@ -1333,8 +1121,6 @@ int16_t Radio::remote_fook(char *payload, size_t payload_len)
 
   readState(state);
 
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    state = ((SX1278 *)lora)->setDataShapingOOK(ook_shape);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             break;
@@ -1359,10 +1145,6 @@ void Radio::remote_SPIwriteRegister(char *payload, size_t payload_len)
   uint8_t data = doc[1];
   Log::console(PSTR("REG ID: 0x%x to 0x%x"), reg, data);
 
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    ((SX1278 *)lora)->_mod->SPIwriteRegister(reg, data);
-//  //  else
-//  //   ((SX1268*)lora)->_mod->SPIwriteRegister(reg,data);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             ((SX1268 *) lora)->_mod->SPIwriteRegister(reg, data);
@@ -1384,10 +1166,6 @@ int16_t Radio::remote_SPIreadRegister(char *payload, size_t payload_len)
   uint8_t data = 0;
 
   int16_t state = 0;
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    data = ((SX1278 *)lora)->_mod->SPIreadRegister(reg);
-//  // else
-//  //   data = ((SX1268*)lora)->_mod->SPIreadRegister(reg);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             data = ((SX1268 *) lora)->_mod->SPIreadRegister(reg);
@@ -1434,10 +1212,6 @@ int16_t Radio::remote_SPIsetRegValue(char *payload, size_t payload_len)
 
   int16_t state = 0;
 
-//  if (ConfigManager::getInstance().getBoardConfig().L_SX127X)
-//    state = ((SX1278 *)lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
-//  else
-//    //   state = ((SX1268*)lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);
     switch (ConfigManager::getInstance().getBoardConfig().L_SX127X) {
         case 0: // SX126x
             state = ((SX1268 *) lora)->_mod->SPIsetRegValue(reg, value, msb, lsb, checkinterval);


### PR DESCRIPTION
Replace if then else logic with switch case logic to allow SX1280 and future transceiver modules.

Added new board definition for:
433/470/868/915 MHz TTGO T3 V2.1.6
2400 MHz ESP32 / E28-2G4MxxS

SX1280 to ESP32  has the following connections:
SCK           5
MISO         19
MOSI         27
NSS          18
RST          23
DIO0/BUSY    26  (LORA IRQ line / Busy)
DIO1         33  (IRQ line)
