### PR TITLE
Beta

### DIFF
--- a/tinyGS/src/ConfigManager/ConfigManager.cpp
+++ b/tinyGS/src/ConfigManager/ConfigManager.cpp
@@ -49,26 +49,26 @@ na   SX1281    2.4–2.5Ghz  130       5.5            2000         0.476-202    
 
 ConfigManager::ConfigManager()
     : IotWebConf2(thingName, &dnsServer, &server, initialApPassword, configVersion), server(80), gsConfigHtmlFormatProvider(*this), boards({
-  //OLED_add, OLED_SDA,  OLED_SCL, OLED_RST, PROG_BUTTON, BOARD_LED, L_SX127X?, L_NSS, L_DI00, L_DI01, L_BUSSY, L_RST,  L_MISO, L_MOSI, L_SCK, L_TCXO_V, BOARD
-  {      0x3c,        4,        15,       16,           0,        25,      1,    18,     26,     12,   UNUSED , 14,      19,     27,     5,     0.0f, "433MHz HELTEC WiFi LoRA 32 V1" },      // SX1278 @4m1g0
-  {      0x3c,        4,        15,       16,           0,        25,      2,    18,     26,     12,   UNUSED , 14,      19,     27,     5,     0.0f, "863-928MHz HELTEC WiFi LoRA 32 V1" },  // SX1276
-  {      0x3c,        4,        15,       16,           0,        25,      1,    18,     26,     35,   UNUSED , 14,      19,     27,     5,     0.0f, "433MHz HELTEC WiFi LoRA 32 V2" },      // SX1278 @4m1g0  
-  {      0x3c,        4,        15,       16,           0,        25,      2,    18,     26,     35,   UNUSED , 14,      19,     27,     5,     0.0f, "863-928MHz HELTEC WiFi LoRA 32 V2" },  // SX1276
-  {      0x3c,        4,        15,       16,           0,         2,      1,    18,     26,   UNUSED, UNUSED , 14,      19,     27,     5,     0.0f, "433Mhz  TTGO LoRa 32 v1"        },     // SX1278 @g4lile0 
-  {      0x3c,        4,        15,       16,           0,         2,      2,    18,     26,   UNUSED, UNUSED , 14,      19,     27,     5,     0.0f, "868-915MHz TTGO LoRa 32 v1"        },  // SX1276
-  {      0x3c,       21,        22,       16,           0,        22,      1,    18,     26,     33,   UNUSED , 14,      19,     27,     5,     0.0f, "433MHz TTGO LoRA 32 v2"        },      // SX1278  @TCRobotics
-  {      0x3c,       21,        22,       16,           0,        22,      2,    18,     26,     33,   UNUSED , 14,      19,     27,     5,     0.0f, "868-915MHz TTGO LoRA 32 v2"        },  // SX1276
-  {      0x3c,       21,        22,       16,          39,        22,      1,    18,     26,     33,     32,    14,      19,     27,     5,     0.0f, "433MHz T-BEAM + OLED"        },        // SX1278
-  {      0x3c,       21,        22,       16,          39,        22,      2,    18,     26,     33,     32,    14,      19,     27,     5,     0.0f, "868-915MHz T-BEAM + OLED"        },    // SX1276
-  {      0x3c,       21,        22,       16,           0,        25,      5,     5,   UNUSED,   27,     26,    14,      19,     23,    18,     0.0f, "Custom ESP32 Wroom + SX126x (Crystal)"  }, // SX1268 @4m1g0, @lillefyr
-  {      0x3c,       21,        22,       16,           0,        25,      5,    18,   UNUSED,   33,     32,    14,      19,     27,     5,     0.0f, "TTGO LoRa 32 V2 Modified with module SX126x (crystal)"  }, // SX1268 @TCRobotics
-  {      0x3c,       21,        22,       16,           0,        25,      5,     5,   UNUSED,    2,     13,    26,      19,     23,    18,     1.6f, "Custom ESP32 Wroom + SX126x DRF1268T (TCX0) (5, 2, 26, 13)"  }, // SX1268 @sdey76
-  {      0x3c,       21,        22,       16,           0,        25,      5,     5,   UNUSED,   26,     12,    14,      19,     23,    18,     1.6f, "Custom ESP32 Wroom + SX126x DRF1268T (TCX0) (5, 26, 14, 12)"  }, // SX1268 @imants
-  {      0x3c,       21,        22,       16,          38,        22,      1,    18,     26,     33,   UNUSED , 14,      19,     27,     5,     0.0f, "433MHz T-BEAM V1.0 + OLED"     },              // SX1278 @fafu
-  {      0x3c,       21,        22,       16,           0,         2,      5,     5,   UNUSED,   34,     32,    14,      19,     27,    18,     1.6f, "433MHz FOSSA 1W Ground Station"  },     // SX1268 @jgromes
-  {      0x3c,       21,        22,       16,           0,         2,      2,     5,   UNUSED,   34,     32,    14,      19,     27,    18,     1.6f, "868-915MHz FOSSA 1W Ground Station"  }, //SX1276 @jgromes
-  {      0x3c,       21,        22,       16,           0,        22,      8,     5,     26,     34,     32,    14,      19,     27,    18,     0.0f, "2.4GHz ESP32 + SX1280"  },              //SX1280 @g4lile0
-  {      0x3c,       21,        22,       16,          38,        22,      2,    18,     26,     33,   UNUSED , 14,      19,     27,     5,     0.0f, "868-915MHzT-BEAM V1.0 + OLED"     },              // SX1278 @fafu
+  //OLED_add, OLED_SDA,  OLED_SCL, OLED_RST, PROG_BUTTON, BOARD_LED, L_SX127X?, L_NSS, L_DI00, L_DI01, L_BUSSY, L_RST,  L_MISO, L_MOSI, L_SCK, L_TCXO_V, RX_EN, TX_EN,   BOARD
+  {      0x3c,        4,        15,       16,           0,        25,      1,    18,     26,     12,   UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "433MHz HELTEC WiFi LoRA 32 V1" },      // SX1278 @4m1g0
+  {      0x3c,        4,        15,       16,           0,        25,      2,    18,     26,     12,   UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "863-928MHz HELTEC WiFi LoRA 32 V1" },  // SX1276
+  {      0x3c,        4,        15,       16,           0,        25,      1,    18,     26,     35,   UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "433MHz HELTEC WiFi LoRA 32 V2" },      // SX1278 @4m1g0  
+  {      0x3c,        4,        15,       16,           0,        25,      2,    18,     26,     35,   UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "863-928MHz HELTEC WiFi LoRA 32 V2" },  // SX1276
+  {      0x3c,        4,        15,       16,           0,         2,      1,    18,     26,   UNUSED, UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "433Mhz  TTGO LoRa 32 v1"        },     // SX1278 @g4lile0 
+  {      0x3c,        4,        15,       16,           0,         2,      2,    18,     26,   UNUSED, UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "868-915MHz TTGO LoRa 32 v1"        },  // SX1276
+  {      0x3c,       21,        22,       16,           0,        22,      1,    18,     26,     33,   UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "433MHz TTGO LoRA 32 v2"        },      // SX1278  @TCRobotics
+  {      0x3c,       21,        22,       16,           0,        22,      2,    18,     26,     33,   UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "868-915MHz TTGO LoRA 32 v2"        },  // SX1276
+  {      0x3c,       21,        22,       16,          39,        22,      1,    18,     26,     33,     32,    14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "433MHz T-BEAM + OLED"        },        // SX1278
+  {      0x3c,       21,        22,       16,          39,        22,      2,    18,     26,     33,     32,    14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "868-915MHz T-BEAM + OLED"        },    // SX1276
+  {      0x3c,       21,        22,       16,           0,        25,      5,     5,   UNUSED,   27,     26,    14,      19,     23,    18,     0.0f,   UNUSED, UNUSED, "Custom ESP32 Wroom + SX126x (Crystal)"  }, // SX1268 @4m1g0, @lillefyr
+  {      0x3c,       21,        22,       16,           0,        25,      5,    18,   UNUSED,   33,     32,    14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "TTGO LoRa 32 V2 Modified with module SX126x (crystal)"  }, // SX1268 @TCRobotics
+  {      0x3c,       21,        22,       16,           0,        25,      5,     5,   UNUSED,    2,     13,    26,      19,     23,    18,     1.6f,   UNUSED, UNUSED, "Custom ESP32 Wroom + SX126x DRF1268T (TCX0) (5, 2, 26, 13)"  }, // SX1268 @sdey76
+  {      0x3c,       21,        22,       16,           0,        25,      5,     5,   UNUSED,   26,     12,    14,      19,     23,    18,     1.6f,   UNUSED, UNUSED, "Custom ESP32 Wroom + SX126x DRF1268T (TCX0) (5, 26, 14, 12)"  }, // SX1268 @imants
+  {      0x3c,       21,        22,       16,          38,        22,      1,    18,     26,     33,   UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "433MHz T-BEAM V1.0 + OLED"     },              // SX1278 @fafu
+  {      0x3c,       21,        22,       16,           0,         2,      5,     5,   UNUSED,   34,     32,    14,      19,     27,    18,     1.6f,   UNUSED, UNUSED, "433MHz FOSSA 1W Ground Station"  },     // SX1268 @jgromes
+  {      0x3c,       21,        22,       16,           0,         2,      2,     5,   UNUSED,   34,     32,    14,      19,     27,    18,     1.6f,   UNUSED, UNUSED, "868-915MHz FOSSA 1W Ground Station"  }, //SX1276 @jgromes
+  {      0x3c,       21,        22,       16,           0,        22,      8,     5,     26,     34,     32,    14,      19,     27,    18,     0.0f,   UNUSED, UNUSED, "2.4GHz ESP32 + SX1280"  },              //SX1280 @g4lile0
+  {      0x3c,       21,        22,       16,          38,        22,      2,    18,     26,     33,   UNUSED , 14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "868-915MHzT-BEAM V1.0 + OLED"     },              // SX1278 @fafu
 
   })
 {
@@ -767,6 +767,8 @@ bool ConfigManager::parseBoardTemplate(board_t &board)
   board.L_MOSI = doc["lMOSI"];
   board.L_SCK = doc["lSCK"];
   board.L_TCXO_V = doc["lTCXOV"];
+  board.RX_EN = doc["RXEN"];
+  board.TX_EN = doc["TXEN"];
 
   return true;
 }

--- a/tinyGS/src/ConfigManager/ConfigManager.h
+++ b/tinyGS/src/ConfigManager/ConfigManager.h
@@ -108,6 +108,8 @@ typedef struct
   uint8_t L_MOSI;
   uint8_t L_SCK;
   float L_TCXO_V;
+  uint8_t RX_EN; 
+  uint8_t TX_EN;
   String BOARD;
 } board_t;
 

--- a/tinyGS/src/Radio/Radio.cpp
+++ b/tinyGS/src/Radio/Radio.cpp
@@ -65,7 +65,13 @@ void Radio::init()
   {
     radioHal = new RadioHal<SX1280>(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
   }
-
+  if (board.RX_EN == 0) board.RX_EN = UNUSED; //@ falta mejorar
+  if (board.TX_EN == 0) board.TX_EN = UNUSED; 
+  if (!((board.RX_EN == UNUSED) && (board.TX_EN == UNUSED))) 
+  { 
+    radioHal -> setRfSwitchPins(board.RX_EN, board.TX_EN);
+    Log::console(PSTR("setRfSwitchPins(RxEn->GPIO-%d, TxEn->GPIO-%d)"),board.RX_EN, board.TX_EN );
+  }
   begin();
 }
 

--- a/tinyGS/src/Radio/RadioHal.hpp
+++ b/tinyGS/src/Radio/RadioHal.hpp
@@ -103,7 +103,7 @@ public:
     return radio->setEncoding(encoding);
   }
   
-  void setRfSwitchPins(uint8_t rxEnPin, uint8_t txEnPin)  //@MODDED
+  void setRfSwitchPins(uint8_t rxEnPin, uint8_t txEnPin)
   {
    radio -> setRfSwitchPins(rxEnPin, txEnPin);
   }

--- a/tinyGS/src/Radio/RadioHal.hpp
+++ b/tinyGS/src/Radio/RadioHal.hpp
@@ -26,6 +26,7 @@ public:
   virtual int16_t setSyncWord(uint8_t* syncWord, uint8_t len) = 0;
   virtual int16_t setFrequency(float freq) = 0;
   virtual int16_t setEncoding(uint8_t encoding) = 0;
+  virtual void setRfSwitchPins(uint8_t rxEnPin, uint8_t txEnPin) = 0;
 };
 
 
@@ -101,8 +102,13 @@ public:
   {
     return radio->setEncoding(encoding);
   }
+  
+  void setRfSwitchPins(uint8_t rxEnPin, uint8_t txEnPin)  //@MODDED
+  {
+   radio -> setRfSwitchPins(rxEnPin, txEnPin);
+  }
 
-
+  
 private:
   T* radio;
 };


### PR DESCRIPTION
Two gpios are added to control rxEn and txEn for radios (E32-M400S30) that require it.
New board definitions are not included, it must be done from "Board Template" in the WEB configuration console,