### PR TITLE
Two gpios have been added to control rxEn and txEn on radios that nee…

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -34,5 +34,5 @@ board = heltec_wifi_lora_32
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
-monitor_port = /dev/ttyUSB*
-upload_port = /dev/ttyUSB*
+monitor_port = COM10
+upload_port = COM10

--- a/tinyGS/src/Mqtt/MQTT_Client.cpp
+++ b/tinyGS/src/Mqtt/MQTT_Client.cpp
@@ -327,7 +327,8 @@ void MQTT_Client::sendAdvParameters()
 bool isValidFrequency(uint8_t radio, float f)
 {
   return !((radio == 1 && (f < 137 || f > 525)) ||
-        (radio == 2 && (f < 137 || f > 525)) ||
+       // (radio == 2 && (f < 137 || f > 525)) ||
+        (radio == 2 && (f < 779 || f > 960)) ||
         (radio == 5 && (f < 410 || f > 810)) ||
         (radio == 6 && (f < 150 || f > 960)) ||
         (radio == 8 && (f < 2400|| f > 2500)));

--- a/tinyGS/src/Mqtt/MQTT_Client.cpp
+++ b/tinyGS/src/Mqtt/MQTT_Client.cpp
@@ -327,11 +327,10 @@ void MQTT_Client::sendAdvParameters()
 bool isValidFrequency(uint8_t radio, float f)
 {
   return !((radio == 1 && (f < 137 || f > 525)) ||
-       // (radio == 2 && (f < 137 || f > 525)) ||
-        (radio == 2 && (f < 779 || f > 960)) ||
-        (radio == 5 && (f < 410 || f > 810)) ||
-        (radio == 6 && (f < 150 || f > 960)) ||
-        (radio == 8 && (f < 2400|| f > 2500)));
+          (radio == 2 && (f < 137 || f > 1020)) ||
+          (radio == 5 && (f < 410 || f > 810)) ||
+          (radio == 6 && (f < 150 || f > 960)) ||
+          (radio == 8 && (f < 2400|| f > 2500)));
 }
 
 void MQTT_Client::manageMQTTData(char *topic, uint8_t *payload, unsigned int length)


### PR DESCRIPTION

In order to use it, you must use the "Board template" from the web console.
Example:  {"name":"E32_400M30S","aADDR":60,"oSDA":4,"oSCL":15,"oRST":16,"pBut":0,"led":25,"radio":1,"lNSS":18,"lDIO0":26,"lDIO1":12,"lBUSSY":"UNUSED","lRST":14,"lMISO":19,"lMOSI":27,"lSCK":5,"lTCXOV":0,"RXEN":32,"TXEN":33}