### PR TITLE
Add ESP32 S2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 scripts/
 tinyGS/tinyGS.ino.cpp
+*.log

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-;PlatformIO Project Configuration File
+; PlatformIO Project Configuration File
 ;
 ;   Build options: build flags, source filter
 ;   Upload options: custom upload port, speed and extra flags
@@ -9,30 +9,38 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-src_dir = tinyGS
-data_dir = tinyGS/data
+src_dir = /Users/tkerby/Github/tinyGS/tinyGS
+data_dir = /Users/tkerby/Github/tinyGS/tinyGS/data
 
 [env]
 build_flags = 
- !python git_rev_macro.py
- -DMQTT_MAX_PACKET_SIZE=1000
- -DCORE_DEBUG_LEVEL=0
- -DIOTWEBCONF_DEBUG_DISABLED=1
- -DARDUINOJSON_USE_LONG_LONG=1
+	!python git_rev_macro.py
+	-DMQTT_MAX_PACKET_SIZE=1000
+	-DCORE_DEBUG_LEVEL=0
+	-DIOTWEBCONF_DEBUG_DISABLED=1
+	-DARDUINOJSON_USE_LONG_LONG=1
 
-# Uncomment these 2 lines by deleting ";" and edit as needed to upload through OTA
-;upload_protocol = espota
-;upload_port = IP_OF_THE_BOARD
-
-
-
-; NOTE: There is no need to change anything below here, the board is configured through the Web panel
-; Only make changes if you know what you are doing
 [env:heltec_wifi_lora_32]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
-monitor_port = /dev/ttyUSB*
-upload_port = /dev/ttyUSB*
+monitor_filters = 
+	log2file
+	time
+	default
+	esp32_exception_decoder
+upload_port = /dev/cu.wchusbserial*
+
+[env:s2mini]
+platform = espressif32
+board = lolin_s2_mini
+framework = arduino
+monitor_speed = 115200
+monitor_filters = 
+	log2file
+	time
+	default
+	esp32_exception_decoder
+upload_speed = 921600

--- a/tinyGS/src/Radio/Radio.cpp
+++ b/tinyGS/src/Radio/Radio.cpp
@@ -32,7 +32,11 @@ bool eInterrupt = true;
 bool noisyInterrupt = false;
 
 Radio::Radio()
-    : spi(VSPI)
+    #ifdef ESP32-S2
+      : spi(FSPI)
+    #else
+      : spi(VSPI)
+    #endif
 {
 }
 


### PR DESCRIPTION
This is a preliminary PR to add support for the S2 chipset by building a second binary file. The only significant change is the naming convention for the SPI pins from VSPI to FSPI.

We need to think about how additional boards may be handles with the auto update mechanism though