### PR TITLE
Add GitHub action to build firmware

### DIFF
--- a/.github/workflows/build-platformio.yml
+++ b/.github/workflows/build-platformio.yml
@@ -33,22 +33,22 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run -e esp32dev
+      run: pio run -e heltec_wifi_lora_32
     - name: Create merged binary
       run: >
-        python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o .pio/build/esp32dev/firmware-full.bin
+        python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o .pio/build/heltec_wifi_lora_32/firmware-full.bin
         0x1000 ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/bin/bootloader_dio_40m.bin
-        0x8000 .pio/build/esp32dev/partitions.bin
+        0x8000 .pio/build/heltec_wifi_lora_32/partitions.bin
         0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin
-        0x10000 .pio/build/esp32dev/firmware.bin
+        0x10000 .pio/build/heltec_wifi_lora_32/firmware.bin
     - name: Rename binaries
       run: |
-        mv .pio/build/esp32dev/firmware.bin .pio/build/esp32dev/tinygs-ota.bin
-        mv .pio/build/esp32dev/firmware-full.bin .pio/build/esp32dev/tinygs-full.bin
+        mv .pio/build/heltec_wifi_lora_32/firmware.bin .pio/build/heltec_wifi_lora_32/tinygs-ota.bin
+        mv .pio/build/heltec_wifi_lora_32/firmware-full.bin .pio/build/heltec_wifi_lora_32/tinygs-full.bin
     - name: Archive build artifacts
       uses: actions/upload-artifact@v3
       with:
         name: firmware
         path: |
-          .pio/build/esp32dev/tinygs-ota.bin
-          .pio/build/esp32dev/tinygs-full.bin
+          .pio/build/heltec_wifi_lora_32/tinygs-ota.bin
+          .pio/build/heltec_wifi_lora_32/tinygs-full.bin

--- a/.github/workflows/build-platformio.yml
+++ b/.github/workflows/build-platformio.yml
@@ -33,22 +33,22 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run -e heltec_wifi_lora_32
+      run: pio run -e default
     - name: Create merged binary
       run: >
-        python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o .pio/build/heltec_wifi_lora_32/firmware-full.bin
+        python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o .pio/build/default/firmware-full.bin
         0x1000 ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/bin/bootloader_dio_40m.bin
-        0x8000 .pio/build/heltec_wifi_lora_32/partitions.bin
+        0x8000 .pio/build/default/partitions.bin
         0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin
-        0x10000 .pio/build/heltec_wifi_lora_32/firmware.bin
+        0x10000 .pio/build/default/firmware.bin
     - name: Rename binaries
       run: |
-        mv .pio/build/heltec_wifi_lora_32/firmware.bin .pio/build/heltec_wifi_lora_32/tinygs-ota.bin
-        mv .pio/build/heltec_wifi_lora_32/firmware-full.bin .pio/build/heltec_wifi_lora_32/tinygs-full.bin
+        mv .pio/build/default/firmware.bin .pio/build/default/tinygs-$(git describe --tags --always)-ota.bin
+        mv .pio/build/default/firmware-full.bin .pio/build/default/tinygs-$(git describe --tags --always)-full.bin
     - name: Archive build artifacts
       uses: actions/upload-artifact@v3
       with:
         name: firmware
         path: |
-          .pio/build/heltec_wifi_lora_32/tinygs-ota.bin
-          .pio/build/heltec_wifi_lora_32/tinygs-full.bin
+          .pio/build/default/tinygs-*-ota.bin
+          .pio/build/default/tinygs-*-full.bin

--- a/.github/workflows/build-platformio.yml
+++ b/.github/workflows/build-platformio.yml
@@ -1,0 +1,54 @@
+name: Build Firmware
+
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v3
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-platformio-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+    - name: Run PlatformIO
+      run: pio run -e esp32dev
+    - name: Create merged binary
+      run: >
+        python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o .pio/build/esp32dev/firmware-full.bin
+        0x1000 ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/bin/bootloader_dio_40m.bin
+        0x8000 .pio/build/esp32dev/partitions.bin
+        0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin
+        0x10000 .pio/build/esp32dev/firmware.bin
+    - name: Rename binaries
+      run: |
+        mv .pio/build/esp32dev/firmware.bin .pio/build/esp32dev/tinygs-ota.bin
+        mv .pio/build/esp32dev/firmware-full.bin .pio/build/esp32dev/tinygs-full.bin
+    - name: Archive build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: firmware
+        path: |
+          .pio/build/esp32dev/tinygs-ota.bin
+          .pio/build/esp32dev/tinygs-full.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,11 +24,9 @@ build_flags =
 ;upload_protocol = espota
 ;upload_port = IP_OF_THE_BOARD
 
-
-
 ; NOTE: There is no need to change anything below here, the board is configured through the Web panel
 ; Only make changes if you know what you are doing
-[env:heltec_wifi_lora_32]
+[env:default]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino


### PR DESCRIPTION
This PR adds a GitHub Action that automatically builds the firmware (in a Ubuntu virtual machine on GitHub's servers) whenever a commit is pushed to the GitHub repository. The output archive contains two files:

- `tinygs-tagname-ful.bin` is a full image containing the second-stage bootloader, partition table and firmware itself. It is suitable for programming with the one-click uploader.
- `tinygs-tagname-ota.bin` contains just the firmware. It is suitable for over-the-air reprogramming.
