### PR TITLE
Handle no OLED reset pin

### DIFF
--- a/tinyGS/src/ConfigManager/ConfigManager.cpp
+++ b/tinyGS/src/ConfigManager/ConfigManager.cpp
@@ -754,7 +754,10 @@ bool ConfigManager::parseBoardTemplate(board_t &board)
   board.OLED__address = doc["aADDR"];
   board.OLED__SDA = doc["oSDA"];
   board.OLED__SCL = doc["oSCL"];
-  board.OLED__RST = doc["oRST"];
+  if (doc.containsKey("oRST"))
+    board.OLED__RST = doc["oRST"];
+  else
+    board.OLED__RST = UNUSED;
   board.PROG__BUTTON = doc["pBut"];
   board.BOARD_LED = doc["led"];
   board.L_radio = doc["radio"];

--- a/tinyGS/src/Display/Display.cpp
+++ b/tinyGS/src/Display/Display.cpp
@@ -19,6 +19,7 @@
 
 #include "Display.h"
 #include "graphics.h"
+#include "../ConfigManager/ConfigManager.h"
 
 SSD1306* display;
 OLEDDisplayUi* ui = NULL;
@@ -63,12 +64,16 @@ void displayInit()
   ui->setFrameAnimation(SLIDE_LEFT);
   ui->setFrames(frames, frameCount);
   ui->setOverlays(overlays, overlaysCount);
+
+  if (board.OLED__RST != UNUSED) {
+    pinMode(board.OLED__RST, OUTPUT);
+    digitalWrite(board.OLED__RST, LOW);
+    delay(50);
+    digitalWrite(board.OLED__RST, HIGH);
+  }
+
+  /* ui init() also initialises the underlying display */
   ui->init();
-  pinMode(board.OLED__RST,OUTPUT);
-  digitalWrite(board.OLED__RST, LOW);     
-  delay(50);
-  digitalWrite(board.OLED__RST, HIGH);   
-  display->init();
 
   if (ConfigManager::getInstance().getFlipOled())
     display->flipScreenVertically();


### PR DESCRIPTION
This PR modifies displayInit() to correctly handle the case where the OLED reset signal is not connected to the ESP32, i.e. board.OLED__RST is set to UNUSED (or oRST is not defined in a custom board template).

The OLED reset signal is not connected to the ESP32 on the TTGO LoRa32 T3 V1.6 board (a.k.a. V2.1.6) for example.
