### PR TITLE
Update SX127x.cpp

### DIFF
--- a/lib/RadioLib/src/modules/SX127x/SX127x.cpp
+++ b/lib/RadioLib/src/modules/SX127x/SX127x.cpp
@@ -1589,8 +1589,8 @@ float SX127x::getRSSI(bool packet, bool skipReceive, int16_t offset) {
     // read the value for FSK
     float rssi = (float)_mod->SPIgetRegValue(RADIOLIB_SX127X_REG_RSSI_VALUE_FSK) / -2.0;
 
-    // set mode back to standby
-    if(!skipReceive) {
+    // set mode back to standby only if skipReceive is True
+    if(skipReceive) {
       standby();
     }
 


### PR DESCRIPTION
It was noted that, in FSK mode, it was not possible to receive a packet with last beta versions. The logic within the main "else" in the method "float SX127x::getRSSI", seemmed to indicate that, if "skipReception" is false the board should be set to start receiving, and then set to standby mode just before returning the RSSI value. This seemed to stop or avoid FSK reception in some way. The logic has been changed in order to set to standby only if the skipReception flag is true. In principle with this change, FSK packets are received and Noise Floor measurement is active and changing in the TinyGS station dashboard.