### PR TITLE
test board 868-915MHz LILYGO T3_V1.6.1 TCXO

### DIFF
--- a/tinyGS/src/ConfigManager/ConfigManager.cpp
+++ b/tinyGS/src/ConfigManager/ConfigManager.cpp
@@ -78,7 +78,7 @@ ConfigManager::ConfigManager()
   {      0x3c,       21,        22,     UNUSED,        38,        22,      RADIO_SX1276,    18,     26,     33,   UNUSED,  14,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "868-915MHz T-BEAM V1.0 + OLED"     },   // SX1276 @fafu
   {      0x3c,       21,        22,     UNUSED,         0,        25,      RADIO_SX1278,    18,     26,     33,   UNUSED,  23,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "433MHz LILYGO T3_V1.6.1"     },         // SX1278
   {      0x3c,       21,        22,     UNUSED,         0,        25,      RADIO_SX1276,    18,     26,     33,   UNUSED,  23,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "868-915MHz LILYGO T3_V1.6.1"     },     // SX1276
-  {      0x3c,       21,        22,     UNUSED,         0,        25,      RADIO_SX1262,    18,     26, RADIOLIB_NC,  32,  23,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "868-915MHz LILYGO T3_V1.6.1 TCXO"    }, // SX1262
+  {      0x3c,       21,        22,     UNUSED,         0,        25,      RADIO_SX1276,    18,     26,   UNUSED,   32,    23,      19,     27,     5,     0.0f,   UNUSED, UNUSED, "868-915MHz LILYGO T3_V1.6.1 TCXO"    }, // SX1262
 
  #endif
   })

--- a/tinyGS/src/ConfigManager/ConfigManager.h
+++ b/tinyGS/src/ConfigManager/ConfigManager.h
@@ -111,7 +111,7 @@ typedef struct
   uint8_t L_radio; // 0 SX1262  1 SX1278
   uint8_t L_NSS;    // CS
   uint8_t L_DI00;
-  uint32_t L_DI01;
+  uint8_t L_DI01;
   uint8_t L_BUSSY;
   uint8_t L_RST;
   uint8_t L_MISO;

--- a/tinyGS/src/Radio/Radio.cpp
+++ b/tinyGS/src/Radio/Radio.cpp
@@ -66,6 +66,14 @@ void Radio::init()
       moduleNameString="SX1278";
       break;
     case RADIO_SX1276:
+      #if CONFIG_IDF_TARGET_ESP32                                    // Heltec Lora 32 V3 patch to enable TCXO
+        if (ConfigManager::getInstance().getBoard()== LILYGO_T3_V1_6_1_HF_TCXO ) { 
+          Log::console(PSTR("[SX1276] Enable TCXO 33... "));
+          pinMode (33, OUTPUT); 
+          digitalWrite(33, HIGH);
+          delay(50);
+        }
+      #endif
       radioHal = new RadioHal<SX1276>(new Module(board.L_NSS, board.L_DI00, board.L_RST, board.L_DI01, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
       moduleNameString="SX1276";
       break;
@@ -74,14 +82,6 @@ void Radio::init()
       moduleNameString="SX1268";
       break;
     case RADIO_SX1262:
-      #if CONFIG_IDF_TARGET_ESP32                                    // Heltec Lora 32 V3 patch to enable TCXO
-        if (ConfigManager::getInstance().getBoard()== LILYGO_T3_V1_6_1_HF_TCXO ) { 
-        Log::console(PSTR("[SX1262] Enable TCXO 33... "));
-        pinMode (33, OUTPUT); 
-        digitalWrite(33, HIGH);
-        delay(50);
-             }
-       #endif
       radioHal = new RadioHal<SX1262>(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
       moduleNameString="SX1262";
       break;

--- a/tinyGS/src/Status.h
+++ b/tinyGS/src/Status.h
@@ -67,7 +67,7 @@ struct TextFrame {
 };
 
 struct Status {
-  const uint32_t version = 2403159; // version year month day release
+  const uint32_t version = 2403161; // version year month day release
   const char* git_version = GIT_VERSION;
   bool mqtt_connected = false;
   bool radio_ready = false;


### PR DESCRIPTION
Por lo que he visto, la placa con txco parece ser idéntica a la otra, solo que se necesita habilitar el oscilador con la IO-33 del esp32.
