### PR TITLE
Adds SoC Temperature + Batt Voltage + BootTime

### DIFF
--- a/tinyGS/src/ConfigManager/ConfigManager.cpp
+++ b/tinyGS/src/ConfigManager/ConfigManager.cpp
@@ -696,6 +696,17 @@ void ConfigManager::parseAdvancedConf()
   {
     advancedConf.lowPower = doc["lowPower"];
   }
+  
+  if (doc.containsKey(F("battery")))
+  {
+    JsonObject batteryConfig = doc["battery"];    
+    if (batteryConfig.containsKey(F("pin")) & batteryConfig.containsKey(F("scale")))
+    {
+      advancedConf.battery = true;
+      advancedConf.battPin = batteryConfig["pin"];
+      advancedConf.battScale = batteryConfig["scale"];
+    }
+  }    
 }
 
 void ConfigManager::parseModemStartup()

--- a/tinyGS/src/ConfigManager/ConfigManager.h
+++ b/tinyGS/src/ConfigManager/ConfigManager.h
@@ -130,6 +130,9 @@ typedef struct
   bool flipOled = true;
   bool dnOled = true;
   bool lowPower = false;
+  bool battery = false;
+  int battPin = 0;
+  float battScale = 0.0;  
 } AdvancedConfig;
 
 class ConfigManager : public IotWebConf2
@@ -190,6 +193,9 @@ public:
   bool getFlipOled() { return advancedConf.flipOled; }
   bool getDayNightOled() { return advancedConf.dnOled; }
   bool getLowPower() { return advancedConf.lowPower; }
+  bool getbattery() { return advancedConf.battery; }
+  int  getbattPin() { return advancedConf.battPin; }
+  float getbattScale() { return advancedConf.battScale; }  
   bool getBoardConfig(board_t &board)
   {
     bool ret = true;

--- a/tinyGS/src/Status.h
+++ b/tinyGS/src/Status.h
@@ -67,8 +67,11 @@ struct TextFrame {
 };
 
 struct Status {
-  const uint32_t version = 2403241; // version year month day release
+  const uint32_t version = 2406101; // version year month day release
   const char* git_version = GIT_VERSION;
+  float ptemp = -1000.0; //processor_temp
+  float vbat  = -1000.0; //battery_voltage
+  time_t bootTime;    
   bool mqtt_connected = false;
   bool radio_ready = false;
   int16_t radio_error = 0;

--- a/tinyGS/tinyGS.ino
+++ b/tinyGS/tinyGS.ino
@@ -210,6 +210,9 @@ void loop() {
   }
 
   // connected
+  getProcessorTemperature();
+  checkBattery();
+  status.bootTime = time (NULL) - millis()/1000;
 
   mqtt.loop();
   OTA::loop();
@@ -319,4 +322,63 @@ void printControls()
   Log::console(PSTR("!b - reboot the board"));
   Log::console(PSTR("!p - send test packet to nearby stations (to check transmission)"));
   Log::console(PSTR("------------------------------------"));
+}
+
+#if CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3
+	#include "driver/temp_sensor.h"
+#else
+	#ifdef __cplusplus
+	extern "C" {
+	uint8_t temprature_sens_read();
+		}
+	#endif
+#endif
+
+void getProcessorTemperature() {
+  // Implementation for getting the processor temperature
+  // Checks temp every 30 sec
+  // Different method for each ESP SoC.
+  #define TEMP_INTERVAL 30000
+  static unsigned long lastTempTime = 0;
+
+	float temperature = -1000.0;
+	if (millis() - lastTempTime > TEMP_INTERVAL) {
+		lastTempTime = millis();
+		#if CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3
+			//float temperature
+			temp_sensor_config_t temp_sensor  = TSENS_CONFIG_DEFAULT();
+			temp_sensor_set_config(temp_sensor);
+			temp_sensor_start();
+			esp_err_t temp_reading = temp_sensor_read_celsius(&temperature);
+			temp_sensor_stop();
+			if (temp_reading != ESP_OK) {
+			  temperature = -1000.0; // Placeholder value for invalid reading
+				}	  
+		#else
+			uint8_t temp_raw = temprature_sens_read();
+			if (temp_raw != 128){
+				temperature = (temp_raw - 32) / 1.8f;			
+				}
+		#endif
+	}
+	status.ptemp = temperature!=-1000.0  ? temperature : status.ptemp;
+}
+
+void checkBattery()
+{// based on mdkendall https://github.com/G4lile0/tinyGS/pull/177/files
+  #define BATTERY_INTERVAL 30000
+  static unsigned long lastReadBattTime = 0;
+  float chng_threshold = 0.15;  // threshold for 15% voltage change
+
+  if (millis() - lastReadBattTime > BATTERY_INTERVAL) {
+    lastReadBattTime = millis();
+    if (configManager.getbattery()) {
+      float vbatMeas = (float)analogReadMilliVolts(configManager.getbattPin()) * configManager.getbattScale() * 0.001f;
+      if (abs(status.vbat - vbatMeas) > chng_threshold * status.vbat) {
+        status.vbat = vbatMeas;
+      } else {
+        status.vbat = (0.75 * status.vbat) + (0.25 * vbatMeas);
+      }
+    }
+  }
 }


### PR DESCRIPTION
With this additions we can track:
 - **Soc Temperature**: It is not infalible, but can help to see if the board its heating, and also to counter frequency drift.
 - **Battery Voltage**: Useful for solar stations.
  With this change the battery sensing pin and the voltage divider multplier could be set freely by the final user.
  Hopefully in the future we can merge it with the _MQTT_Client::voltage()_ function.
`{"battery":{"pin":int XX, "scale": floatYY}}`
ie:`{"battery":{"pin":15, "scale": 1.9}}`
- **BootTime**: UnixTime in seconds. This could help to see if the board is having reboots.

I'm preparing more additions. You can see them here:
https://github.com/G4lile0/tinyGS/compare/beta...gargomoma:tinyGS:beta_extras_246