### PR TITLE
Pn9(8b fixed) de whitening

### DIFF
--- a/tinyGS/src/BitCode/BitCode.cpp
+++ b/tinyGS/src/BitCode/BitCode.cpp
@@ -321,6 +321,31 @@ int BitCode::nrz2ax25(uint8_t *entrada, size_t sizeEntrada, uint8_t *ax25bin, si
 }
 
 
+/*  
+    ////////////////////////////////////////////////////////////////
+    About bit position convention:
+    ------------------------------
+    The posicion for reading or writing a bit is numbered from 
+    LSB to MSB beginning in "1" That is to say, the position 4th is:
+    
+    00001000
+        ^   
+
+    About shifting bits:
+    --------------------
+    Shift bits to the left will introduce zeros by the right.
+    e.g. 00000001 << 3 = 00001000
+
+    For setting a bit to zero:
+    --------------------------
+    For bit selection, a one in byte_aux is rotated to the desire 
+    position. Then a mask is done complementing byte_aux to set the 
+    zeros in ones and viceversa. When applying the AND operation, 
+    everything will remain equal, except the bit in the position of 
+    bit zero, which will be set to zero.
+    ////////////////////////////////////////////////////////////////
+*/
+
 int read_bit (uint32_t dato, int posicion){
   int test=1;
   int resultado=0;
@@ -329,16 +354,9 @@ int read_bit (uint32_t dato, int posicion){
   if (resultado==0){return 0;}else{return 1;}
 }
 
-/** The posicion is numbered from LSB to MSB beginning in "1".
-    That is to say, the position 4th is 00001000
-*/
 void write_bit(uint32_t *byte, int posicion, int dato){
   int byte_aux = 1;
-  //Al rotar se introducen ceros por la derecha.
   byte_aux = byte_aux << (posicion-1); 
-  //Para setear a cero, hacemos una mascara complementado byte_aux para convetir los ceros en unos,
-  //y el uno del bit a setear en cero. Al hacer el AND bit a bit, dejaremos lo demás bits como estan
-  //y el bit con la posición del bit a cero, quedará a cero.
   if (dato==0){*byte = *byte & ~byte_aux;} 
   if (dato==1){*byte = *byte | byte_aux;}
 }
@@ -352,7 +370,7 @@ int BitCode::pn9(uint8_t *entrada, size_t sizeEntrada, uint8_t *salida){
         write_bit(&pn9,10,(read_bit(pn9,1)^read_bit(pn9,6)));
 		    pn9 >>= 1;
         pn9 &= mask;
-	    }//Fin Efectua 8 desplazamientos
+	    }
     }
     return 0;
   }

--- a/tinyGS/src/BitCode/BitCode.cpp
+++ b/tinyGS/src/BitCode/BitCode.cpp
@@ -319,3 +319,40 @@ int BitCode::nrz2ax25(uint8_t *entrada, size_t sizeEntrada, uint8_t *ax25bin, si
       return 1;
 	  }
 }
+
+
+int read_bit (uint32_t dato, int posicion){
+  int test=1;
+  int resultado=0;
+  test <<= (posicion-1);
+  resultado=dato & test;
+  if (resultado==0){return 0;}else{return 1;}
+}
+
+/** The posicion is numbered from LSB to MSB beginning in "1".
+    That is to say, the position 4th is 00001000
+*/
+void write_bit(uint32_t *byte, int posicion, int dato){
+  int byte_aux = 1;
+  //Al rotar se introducen ceros por la derecha.
+  byte_aux = byte_aux << (posicion-1); 
+  //Para setear a cero, hacemos una mascara complementado byte_aux para convetir los ceros en unos,
+  //y el uno del bit a setear en cero. Al hacer el AND bit a bit, dejaremos lo demás bits como estan
+  //y el bit con la posición del bit a cero, quedará a cero.
+  if (dato==0){*byte = *byte & ~byte_aux;} 
+  if (dato==1){*byte = *byte | byte_aux;}
+}
+
+int BitCode::pn9(uint8_t *entrada, size_t sizeEntrada, uint8_t *salida){
+    uint32_t pn9 =0x000001FF;
+    uint32_t mask=0x000001FF;
+    for (int b=0;b<sizeEntrada;b++){
+            salida[b]=entrada[b]^pn9;
+	    for (int k=0;k<8;k++){ 
+        write_bit(&pn9,10,(read_bit(pn9,1)^read_bit(pn9,6)));
+		    pn9 >>= 1;
+        pn9 &= mask;
+	    }//Fin Efectua 8 desplazamientos
+    }
+    return 0;
+  }

--- a/tinyGS/src/BitCode/BitCode.h
+++ b/tinyGS/src/BitCode/BitCode.h
@@ -31,5 +31,6 @@ static int remove_bit_stuffing (uint8_t *entrada, size_t sizeEntrada, uint8_t *s
 static void invierte_bits_de_un_byte(uint8_t br, uint8_t *bs);
 static void invierte_bytes_de_un_array(uint8_t *entrada, size_t sizeEntrada, uint8_t *salida, size_t *sizeSalida);
 static int nrz2ax25(uint8_t *entrada, size_t sizeEntrada,  uint8_t *ax25bin, size_t *sizeAx25bin);
+static int pn9(uint8_t *entrada, size_t sizeEntrada, uint8_t *salida);
 };
 #endif

--- a/tinyGS/src/Radio/Radio.cpp
+++ b/tinyGS/src/Radio/Radio.cpp
@@ -509,7 +509,15 @@ uint8_t Radio::listen()
         respFrame=ax25bin;
         respLen=sizeAx25bin;
       }
-            
+
+      if (status.modeminfo.framing==2){ //framing=2 -> PN9(Fixed 8 bits shift) de-scrambler
+        uint8_t *salida;
+        size_t sizeSalida=0;              
+        salida=new uint8_t[respLen];
+        BitCode::pn9(respFrame,respLen,salida);
+        respFrame=salida;
+      }
+
       if (frame_error==0 && status.modeminfo.crc_by_sw){
         size_t newsize=respLen-status.modeminfo.crc_nbytes;
         RadioLibCRCInstance.size = status.modeminfo.crc_nbytes*8;


### PR DESCRIPTION
This pull request add a new framing feature to the FSK section.

Some satellites may use a PN9 whitening encoding to the data transmitted. Before performing CRC check and having the packet ready for further processing, the bit stream needs to be de-scrambled. This pull request provides a PN9 de-scramble in the BitCode class, and a piece of software in the Radio class to handle this new packet encoding, which will be identified as fr=2.