### PR TITLE
Fixed typo error in "modules" word

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TinyGS is an open network of Ground Stations distributed around the world to rec
 
 # Hardware
 
-This project is based on ESP32 boards and currently it is compatible with sx126x and sx127x LoRa módules but we plan to support more radio módules in the future.
+This project is based on ESP32 boards and currently it is compatible with sx126x and sx127x LoRa modules but we plan to support more radio modules in the future.
 
 Currently we are officially supporting the following proven LoRa boards:
 
@@ -24,7 +24,7 @@ Currently we are officially supporting the following proven LoRa boards:
 - **ESP32-S3 150–960Mhz - HELTEC LORA32 V3 SX1262**
 - **ESP32-S3 433Mhz Custom ESP32-S3 433MHz SX1278**
 
-However, any ESP32 board with sx126x or sx127x módule can be configured using templates. You can find more info about them [here](https://github.com/G4lile0/tinyGS/wiki/Board-Templates).
+However, any ESP32 board with sx126x or sx127x module can be configured using templates. You can find more info about them [here](https://github.com/G4lile0/tinyGS/wiki/Board-Templates).
 
 # Install
 


### PR DESCRIPTION
This is a tiny PR. The main purpose is correct typo errors in "module" word in README.md"
Nothing more