### PR TITLE
fix: add missing break in RADIO_SX1280 switch case

### DIFF
--- a/tinyGS/src/Radio/Radio.cpp
+++ b/tinyGS/src/Radio/Radio.cpp
@@ -88,6 +88,7 @@ void Radio::init()
     case RADIO_SX1280:
       radioHal = new RadioHal<SX1280>(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
       moduleNameString="SX1280";
+      break;
     default:
        radioHal = new RadioHal<SX1268>(new Module(board.L_NSS, board.L_DI01, board.L_RST, board.L_BUSSY, spi, SPISettings(2000000, MSBFIRST, SPI_MODE0)));
        moduleNameString="default SX1268";


### PR DESCRIPTION
Found a missing `break` in the switch statement in `Radio::init()` that affects all SX1280 boards.

## What's happening

The `RADIO_SX1280` case falls straight through into `default`, so the SX1280 RadioHal gets created and then immediately overwritten by an SX1268 one:

```cpp
case RADIO_SX1280:
    radioHal = new RadioHal<SX1280>(...);
    moduleNameString="SX1280";
    // no break here!
default:
    radioHal = new RadioHal<SX1268>(...);
    moduleNameString="default SX1268";
```

So any board set up for SX1280 (like the LilyGo T3S3 2.4GHz) ends up running the SX1268 driver instead, which either fails to init or just doesn't work right. The SX1280 object also leaks since nothing ever frees it.

## The fix

Just added the missing `break;` — same as every other case in the switch already has.

```diff
     case RADIO_SX1280:
       radioHal = new RadioHal<SX1280>(...);
       moduleNameString="SX1280";
+      break;
     default:
```

Probably the root cause (or at least part of it) for #280.