### PR TITLE
fix(deps): Pin radiolib version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
     improv/Improv@^1.2.4
     ;jgromes/RadioLib @ 7.6.0
     ;https://github.com/jgromes/RadioLib/archive/refs/heads/master.zip
-    https://github.com/G4lile0/RadioLib.git
+    https://github.com/G4lile0/RadioLib.git#c778d8767d47e0bfb015dfd762d0699b0d5001fd
 # Uncomment these 2 lines by deleting ";" and edit as needed to upload through OTA
 ;upload_protocol = espota
 ;upload_port = IP_OF_THE_BOARD


### PR DESCRIPTION
The build from source is currently broken, as the latest version of Radiolib in that git repository is different than the version that the `.ino` file asserts via C macros.

Dependency versions should be pinned. The benefits include security and resistance to supply chain attacks (which can target the build computer - not just the microcontroller). 

