### PR TITLE
chore: commit changes that VS Code insists on

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
+        "Jason2866.esp-decoder",
         "pioarduino.pioarduino-ide",
         "platformio.platformio-ide"
     ],

--- a/tinyGS/idf_component.yml
+++ b/tinyGS/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  idf: '>=5.1'


### PR DESCRIPTION
VS Code insists on making these changes, in the nominal setup. It'd be easier just to commit them to avoid having to excluded them from commits everytime. 