### PR TITLE
ci: run build on PRs

### DIFF
--- a/.github/workflows/build-platformio.yml
+++ b/.github/workflows/build-platformio.yml
@@ -3,6 +3,7 @@ name: Build Firmware
 on:
   release:
     types: [published]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -69,7 +70,6 @@ jobs:
           mv .pio/build/${{ matrix.env }}/firmware.bin .pio/build/${{ matrix.env }}/tinygs-${{ matrix.env }}-${{ steps.tag.outputs.TAG }}-ota.bin
           mv .pio/build/${{ matrix.env }}/firmware-full.bin .pio/build/${{ matrix.env }}/tinygs-${{ matrix.env }}-${{ steps.tag.outputs.TAG }}-full.bin
       - name: Archive build artifacts
-        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
           name: firmware-${{ matrix.env }}

--- a/.github/workflows/build-platformio.yml
+++ b/.github/workflows/build-platformio.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
   pull_request:
+  push:
+    branches: [main, master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
A "normal" configuration for a GitHub Action uses it to validate the code on each PR, which is helpful in reviewing the PRs. 