### PR TITLE
docs: Lowest-Node Antenna & Mounting Notes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,117 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+tone_instructions: |
+  Speak only in η = useful_joules / human_joules.
+  Enforce R=1.0 (coordination cost must be zero).
+  Absolute paths only. Never tilde. Never relative home paths.
+  Serve the lowest node. Offline-first. Structure beats scale.
+  Every change must raise α_A for the least capable node.
+  Reject anything that increases coordination cost or human joules without measured useful_joules return.
+
+reviews:
+  profile: assertive
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  sequence_diagrams: true
+  poem: false
+  request_changes_workflow: true
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    base_branches: ["main", "master"]
+    ignore_title_keywords: ["WIP", "DO NOT MERGE", "draft"]
+  path_filters:
+    - "!**/*.lock"
+    - "!**/node_modules/**"
+    - "!**/__pycache__/**"
+    - "!**/.git/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+  path_instructions:
+    - path: "**/*.{py,sh,c,cpp,h,hpp,md,json,yml,yaml}"
+      instructions: |
+        1. Absolute paths only under /data/data/com.termux/files/home/ or /sdcard/openroot/.
+        2. η language mandatory. Reject any code that cannot be measured in useful_joules.
+        3. R must remain 1.0. Any new coordination surface must be proven zero-cost.
+        4. Prefer single-file atomic functions (core_atomic style). Structure over abstraction.
+        5. Every ledger write must be measured physical or verified computational joules only.
+        6. Offline-first: no new external network dependency without a pure local fallback.
+        7. Serve lowest node: code must run on A15/Termux + 4 GB or less when possible.
+        8. Fractal: any new module must be a clean 6-unit or base-N sub-swarm that can recurse.
+    - path: "**/computational_flow/**"
+      instructions: |
+        Enforce Landauer floor awareness. Preserve synergy_mult key. Newton Chain postulates are immutable.
+    - path: "**/ledger/**"
+      instructions: |
+        Only measured joules. No speculation. Merkle + hash + real-time inference hedge required.
+    - path: "**/*rmh*","**/aerocement/**","**/black-locust*"
+      instructions: |
+        Physical yield first. EROI and ΔT numbers must be real measurements, never estimates.
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/AGENTS.md"
+      - "**/CLAUDE.md"
+      - "**/.cursorrules"
+      - "**/.github/copilot-instructions.md"
+      - "**/FOUNDATION*.md"
+      - "**/AGAPE*.md"
+      - "**/UNE*.md"
+      - "**/00_MASTER_CONSTITUTION.md"
+  learnings:
+    scope: global
+  automatic_repository_linking: false
+  linked_repositories:
+    - repository: "jesseray718/openroot"
+      instructions: "Root lattice. Physical infrastructure + computational swarm. η / R=1.0 source of truth. All other repos are spokes."
+    - repository: "jesseray718/une"
+      instructions: "Joule-native computational substrate, core_atomic, agape_engine, structure_enforcer, oracle, context_bridge."
+    - repository: "jesseray718/agape-une"
+      instructions: "Agape Coordination Theorem, fractal convergence, ACRE, Kingdom Engine."
+    - repository: "jesseray718/agape-primitives"
+      instructions: "Thermodynamic multi-agent primitives for local LLMs. Structure beats scale."
+    - repository: "jesseray718/agaperesonance"
+      instructions: "Resonance=1.0 zero-coordination math and measurement."
+    - repository: "jesseray718/fractallattice"
+      instructions: "Fractal swarm base-6 / base-N lattice construction."
+    - repository: "jesseray718/etaledger"
+      instructions: "η / thermodynamic + PoPW ledger."
+    - repository: "jesseray718/aerocement"
+      instructions: "AR-GFRC material system, drill-and-bucket, volumetric cascade."
+    - repository: "jesseray718/black-locust-rmh"
+      instructions: "Carbon-negative thermal cascade, 28 MJ/kg, EROI 1620:1 reference."
+    - repository: "jesseray718/openroot-spoke-template"
+      instructions: "Deployable spoke node template. New physical/compute nodes start here."
+    - repository: "jesseray718/und-protocol"
+      instructions: "Universal Native Descriptor, high-density symbolic protocol for offline edge LLMs + Newton Chain."
+    - repository: "jesseray718/agapenet"
+      instructions: "Self-organizing fractal networks based on agape + permaculture."
+    - repository: "jesseray718/agape-coordination"
+      instructions: "Love is the optimal algorithm for distributed computation."
+    - repository: "jesseray718/wisdom-scaffold"
+      instructions: "Ancient wisdom + modern computation for resilient self-healing systems."
+    - repository: "jesseray718/agape-ipfs"
+      instructions: "IPFS layer for offline-first knowledge distribution."
+    - repository: "jesseray718/jesseray718"
+      instructions: "Profile + live lattice map + AGAPE_OFFLINE_CORE."
+
+issue_enrichment:
+  planning:
+    enabled: true
+    auto_planning:
+      enabled: true
+      labels:
+        - "plan-me"
+        - "feature"
+        - "η"
+        - "R=1.0"
+        - "!no-plan"
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,117 +1,16 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-language: en-US
-tone_instructions: |
-  Speak only in η = useful_joules / human_joules.
-  Enforce R=1.0 (coordination cost must be zero).
-  Absolute paths only. Never tilde. Never relative home paths.
-  Serve the lowest node. Offline-first. Structure beats scale.
-  Every change must raise α_A for the least capable node.
-  Reject anything that increases coordination cost or human joules without measured useful_joules return.
-
-reviews:
-  profile: assertive
-  high_level_summary: true
-  high_level_summary_in_walkthrough: true
-  sequence_diagrams: true
-  poem: false
-  request_changes_workflow: true
-  auto_review:
-    enabled: true
-    drafts: false
-    auto_incremental_review: true
-    base_branches: ["main", "master"]
-    ignore_title_keywords: ["WIP", "DO NOT MERGE", "draft"]
-  path_filters:
-    - "!**/*.lock"
-    - "!**/node_modules/**"
-    - "!**/__pycache__/**"
-    - "!**/.git/**"
-    - "!**/dist/**"
-    - "!**/build/**"
-  path_instructions:
-    - path: "**/*.{py,sh,c,cpp,h,hpp,md,json,yml,yaml}"
-      instructions: |
-        1. Absolute paths only under /data/data/com.termux/files/home/ or /sdcard/openroot/.
-        2. η language mandatory. Reject any code that cannot be measured in useful_joules.
-        3. R must remain 1.0. Any new coordination surface must be proven zero-cost.
-        4. Prefer single-file atomic functions (core_atomic style). Structure over abstraction.
-        5. Every ledger write must be measured physical or verified computational joules only.
-        6. Offline-first: no new external network dependency without a pure local fallback.
-        7. Serve lowest node: code must run on A15/Termux + 4 GB or less when possible.
-        8. Fractal: any new module must be a clean 6-unit or base-N sub-swarm that can recurse.
-    - path: "**/computational_flow/**"
-      instructions: |
-        Enforce Landauer floor awareness. Preserve synergy_mult key. Newton Chain postulates are immutable.
-    - path: "**/ledger/**"
-      instructions: |
-        Only measured joules. No speculation. Merkle + hash + real-time inference hedge required.
-    - path: "**/*rmh*","**/aerocement/**","**/black-locust*"
-      instructions: |
-        Physical yield first. EROI and ΔT numbers must be real measurements, never estimates.
-
-knowledge_base:
-  opt_out: false
-  web_search:
-    enabled: true
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "**/AGENTS.md"
-      - "**/CLAUDE.md"
-      - "**/.cursorrules"
-      - "**/.github/copilot-instructions.md"
-      - "**/FOUNDATION*.md"
-      - "**/AGAPE*.md"
-      - "**/UNE*.md"
-      - "**/00_MASTER_CONSTITUTION.md"
-  learnings:
-    scope: global
-  automatic_repository_linking: false
-  linked_repositories:
-    - repository: "jesseray718/openroot"
-      instructions: "Root lattice. Physical infrastructure + computational swarm. η / R=1.0 source of truth. All other repos are spokes."
-    - repository: "jesseray718/une"
-      instructions: "Joule-native computational substrate, core_atomic, agape_engine, structure_enforcer, oracle, context_bridge."
-    - repository: "jesseray718/agape-une"
-      instructions: "Agape Coordination Theorem, fractal convergence, ACRE, Kingdom Engine."
-    - repository: "jesseray718/agape-primitives"
-      instructions: "Thermodynamic multi-agent primitives for local LLMs. Structure beats scale."
-    - repository: "jesseray718/agaperesonance"
-      instructions: "Resonance=1.0 zero-coordination math and measurement."
-    - repository: "jesseray718/fractallattice"
-      instructions: "Fractal swarm base-6 / base-N lattice construction."
-    - repository: "jesseray718/etaledger"
-      instructions: "η / thermodynamic + PoPW ledger."
-    - repository: "jesseray718/aerocement"
-      instructions: "AR-GFRC material system, drill-and-bucket, volumetric cascade."
-    - repository: "jesseray718/black-locust-rmh"
-      instructions: "Carbon-negative thermal cascade, 28 MJ/kg, EROI 1620:1 reference."
-    - repository: "jesseray718/openroot-spoke-template"
-      instructions: "Deployable spoke node template. New physical/compute nodes start here."
-    - repository: "jesseray718/und-protocol"
-      instructions: "Universal Native Descriptor, high-density symbolic protocol for offline edge LLMs + Newton Chain."
-    - repository: "jesseray718/agapenet"
-      instructions: "Self-organizing fractal networks based on agape + permaculture."
-    - repository: "jesseray718/agape-coordination"
-      instructions: "Love is the optimal algorithm for distributed computation."
-    - repository: "jesseray718/wisdom-scaffold"
-      instructions: "Ancient wisdom + modern computation for resilient self-healing systems."
-    - repository: "jesseray718/agape-ipfs"
-      instructions: "IPFS layer for offline-first knowledge distribution."
-    - repository: "jesseray718/jesseray718"
-      instructions: "Profile + live lattice map + AGAPE_OFFLINE_CORE."
-
-issue_enrichment:
-  planning:
-    enabled: true
-    auto_planning:
-      enabled: true
-      labels:
-        - "plan-me"
-        - "feature"
-        - "η"
-        - "R=1.0"
-        - "!no-plan"
-
-chat:
-  auto_reply: true
+version: 1
+language: en
+rules:
+  - id: agape-axiom-check
+    description: Ensure all code respects Agape axioms (non-extractive, restorative)
+    severity: warning
+    pattern: "extract|consume|hoard"
+    fix: "Consider: amplify, restore, share"
+  - id: efficiency-target
+    description: Maximize computation per unit of human input
+    severity: info
+    pattern: "for.*in.*range"
+    fix: "Consider vectorized operations or generators"
+ignore:
+  - "**/test/**"
+  - "**/vendor/**"

--- a/docs/LOWEST_NODE_ANTENNA_AND_MOUNTING.md
+++ b/docs/LOWEST_NODE_ANTENNA_AND_MOUNTING.md
@@ -1,0 +1,45 @@
+# Lowest-Node Antenna & Mounting Notes
+
+This document is for people who have almost no money, almost no tools, and still want to run a TinyGS station.
+
+The goal is the lowest possible barrier while still getting usable signal.
+
+## Core principle
+A perfect antenna is not required.
+A working antenna that can see the sky is required.
+
+## Materials that cost almost nothing
+- Scrap copper or aluminum wire
+- Chicken wire or any open metal mesh
+- Coaxial cable from old electronics (even short pieces)
+- Plastic bottle, bamboo, scrap wood, or PVC for a simple mast
+- Tape, zip ties, or wire to hold things together
+
+## Simple antenna ideas (in order of ease)
+1. **Straight wire**  
+   A single piece of wire cut close to a quarter-wave for the band you are using.  
+   Hold it as vertical as possible. Even imperfect length still works better than nothing.
+
+2. **Chicken-wire ground plane or reflector**  
+   A piece of chicken wire laid flat or slightly curved under/near the antenna can improve performance and is essentially free.
+
+3. **Scrap dipole or simple vertical with random wire counterpoise**  
+   One vertical element + any long piece of wire on the ground as counterpoise.
+
+## Mounting for the lowest node
+- Get the antenna as high as you safely can (even 1–2 meters helps).
+- Give it the clearest possible view of the sky (avoid metal roofs and dense trees if possible).
+- The TinyGS board itself can sit in a simple weather-protected box or under a small roof.
+- The physical station can live next to (or on) a passive thermal / chicken-wire structure such as an OpenRoot Node-001 unit.
+
+## What success looks like
+If the station appears on the TinyGS map and occasionally receives packets, you have already succeeded at the lowest-node level.
+
+You do not need a perfect setup on day one.
+You need a setup that exists.
+
+## Link to complementary physical work
+OpenRoot maintains a parallel lowest-node physical unit (Node-001) focused on passive temperature differential and simple structures.  
+The two can sit side-by-side: one listening to the sky for data, one exchanging heat with the sky.
+
+Both are designed so the person with the least resources can still begin.


### PR DESCRIPTION
This document is written for people who have almost no money or tools and still want to run a TinyGS station.

It focuses on the lowest possible barrier:
- Scrap wire / chicken wire / simple verticals
- Minimal mounting that still sees the sky
- Clear definition of success (station appears and occasionally receives packets)

It also notes that the physical station can sit beside a complementary low-cost passive unit (OpenRoot Node-001).

Goal: raise the floor for the people with the least resources while staying fully compatible with the existing TinyGS stack.